### PR TITLE
Auth connection support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ jdk:
   - oraclejdk7  # needed for local Neo4j 2.0+
 
 env:
-  - NEO4J_VERSION="2.0.3"
+  - NEO4J_VERSION="2.1.6"
+  - NEO4J_VERSION="2.2.2"
 
 notifications:
   slack:

--- a/Examples/Movies/config/database.php
+++ b/Examples/Movies/config/database.php
@@ -8,6 +8,8 @@ $config = [
     'driver' => 'neo4j',
     'host'   => 'dev',
     'port'   => 7474,
+    'username' => 'neo4j',
+    'password' => 'neo4j'
 ];
 
 $capsule = new Capsule;

--- a/src/Vinelab/NeoEloquent/Connection.php
+++ b/src/Vinelab/NeoEloquent/Connection.php
@@ -64,7 +64,7 @@ class Connection extends IlluminateConnection {
     public function createConnection()
     {
         return ClientBuilder::create()
-            ->addConnection('default', 'http', $this->getHost(), $this->getPort())
+            ->addConnection('default', 'http', $this->getHost(), $this->getPort(), $this->isSecured(), $this->getUsername(), $this->getPassword())
             ->setAutoFormatResponse(true)
             ->build();
     }
@@ -118,6 +118,15 @@ class Connection extends IlluminateConnection {
     public function getUsername()
     {
         return $this->getConfig('username', $this->defaults['username']);
+    }
+
+    /**
+     * Returns whether or not the connection should be secured
+     * @return bool
+     */
+    public function isSecured()
+    {
+        return null !== $this->getUsername() && null !== $this->getPassword();
     }
 
     /**


### PR DESCRIPTION
* Add new method `isSecured` in Connection and modified `createConnection` to build a secured connection when needed

* Modified Movies example config with default auth

* Bumped Neo4j versions in `travis.yml` as NeoClient supports only Neo4j 2.1.6+