### PR TITLE
Overriding Builder's first() method so it will return the first result correctly

### DIFF
--- a/src/Vinelab/NeoEloquent/Query/Builder.php
+++ b/src/Vinelab/NeoEloquent/Query/Builder.php
@@ -685,6 +685,19 @@ class Builder extends IlluminateQueryBuilder {
     }
 
     /**
+     * Execute the query and get the first result.
+     *
+     * @param  array   $columns
+     * @return mixed|static
+     */
+    public function first($columns = array('*'))
+    {
+        $results = $this->take(1)->get($columns)->current();
+
+        return (isset($results[0]) && count($results[0]) > 0) ? $results[0]->getProperties() : null;
+    }
+
+    /**
      * Execute an aggregate function on the database.
      *
      * @param  string  $function


### PR DESCRIPTION
I added this functionality for #69, but I think it'll prove useful for other situations.

The reset() call in the parent Builder class was causing NeoEloquent's Builder to return the Client object instead of the properties of the Node.