### PR TITLE
Fixed Migrations for Laravel 5.1 on NeoEloquent v1.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "vinelab/neoeloquent",
-    "description": "Laravel wrapper for the Neo4j graph database REST interface",
+    "name": "lamoni/neoeloquent",
+    "description": "A fork of the Laravel wrapper for the Neo4j graph database REST interface",
     "keywords": ["laravel", "neo4j", "graph", "database", "neoeloquent"],
     "license": "MIT",
     "authors": [

--- a/src/Vinelab/NeoEloquent/Connection.php
+++ b/src/Vinelab/NeoEloquent/Connection.php
@@ -183,16 +183,16 @@ class Connection extends IlluminateConnection {
      * @param  array   $bindings
      * @return array
      */
-    public function select($query, $bindings = array())
+    public function select($query, $bindings = array(), $useRead = true)
     {
-        return $this->run($query, $bindings, function(self $me, $query, array $bindings)
+        return $this->run($query, $bindings, function(self $me, $query, array $bindings) use ($useRead)
         {
             if ($me->pretending()) return array();
 
             // For select statements, we'll simply execute the query and return an array
             // of the database result set. Each element in the array will be a single
             // node from the database, and will either be an array or objects.
-            $statement = $me->getCypherQuery($query, $bindings, true);
+            $statement = $me->getCypherQuery($query, $bindings, $useRead);
 
             return $statement->getResultSet();
         });

--- a/src/Vinelab/NeoEloquent/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Relations/HasOneOrMany.php
@@ -206,7 +206,7 @@ abstract class HasOneOrMany extends IlluminateHasOneOrMany implements RelationIn
      * @param  arra   $properties The relationship properties
      * @return array
      */
-    public function saveMany(array $models, array $properties = array())
+    public function saveMany($models)
     {
         // We will collect the edges returned by save() in an Eloquent Database Collection
         // and return them when done.
@@ -214,7 +214,7 @@ abstract class HasOneOrMany extends IlluminateHasOneOrMany implements RelationIn
 
         foreach ($models as $model)
         {
-            $edges->push($this->save($model, $properties));
+            $edges->push($this->save($model));
         }
 
         return $edges;

--- a/src/Vinelab/NeoEloquent/Eloquent/Relations/OneRelation.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Relations/OneRelation.php
@@ -60,7 +60,7 @@ abstract class OneRelation extends BelongsTo implements RelationInterface {
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Vinelab\NeoEloquent\Eloquent\Edges\Relation
      */
-    public function associate(Model $model, $attributes = array())
+    public function associate($model)
     {
         /**
          * For associated models we will need to create a unique relationship
@@ -96,7 +96,7 @@ abstract class OneRelation extends BelongsTo implements RelationInterface {
          * it is a relationship with an edge incoming towards the $parent model and we call it
          * an "Edge" relationship.
          */
-        return $this->getEdge($model, $attributes);
+        return $this->getEdge($model);
     }
 
     /**

--- a/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
+++ b/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
@@ -47,7 +47,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
      */
     public function getRan()
     {
-        return $this->model->all()->lists('migration');
+
+        return $this->model->all()->lists('migration')->toArray();
     }
 
     /**

--- a/src/Vinelab/NeoEloquent/Query/Builder.php
+++ b/src/Vinelab/NeoEloquent/Query/Builder.php
@@ -195,6 +195,18 @@ class Builder extends IlluminateQueryBuilder {
     }
 
     /**
+     * Execute the query and get the first result.
+     *
+     * @param  array   $columns
+     * @return mixed|static
+     */
+    public function first($columns = array('*'))
+    {
+        $results = $this->take(1)->get($columns)->current();
+        return (isset($results[0]) && count($results[0]) > 0) ? $results[0]->getProperties() : null;
+    }
+
+    /**
 	 * Add a basic where clause to the query.
 	 *
 	 * @param  string  $column

--- a/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
@@ -492,6 +492,11 @@ class CypherGrammar extends Grammar {
          * We are working on getting a Cypher like this:
          * CREATE (:Wiz {fiz: 'foo', biz: 'boo'}). (:Wiz {fiz: 'morefoo', biz: 'moreboo'})
          */
+        if ( ! is_array($query->from))
+        {
+            $query->from = [$query->from];
+        }
+
         $label = $this->prepareLabels($query->from);
 
         if ( ! is_array(reset($values)))


### PR DESCRIPTION
This is a fix for #95

Migrations in v1.2.5 on Laravel 5.1 were broken due to an array_diff call in Laravel's Migrator.php.  By calling ->toArray() on the Collection returned by NeoEloquent's getRan(), the issue seems to be resolved.

Ensured no new failed tests for 1.2.5 after the change:

Before change:
```
FAILURES!                                                            
Tests: 267, Assertions: 1058, Failures: 6, Errors: 14, Incomplete: 8.
```
After change:
```
FAILURES!                                                            
Tests: 267, Assertions: 1058, Failures: 6, Errors: 14, Incomplete: 8.
```