### PR TITLE
Patch to fix issue 49 "Where conditions on related entities, case sensitivity issue on the alias in query"

### DIFF
--- a/src/Vinelab/NeoEloquent/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Relations/HasOneOrMany.php
@@ -206,7 +206,7 @@ abstract class HasOneOrMany extends IlluminateHasOneOrMany implements RelationIn
      * @param  arra   $properties The relationship properties
      * @return array
      */
-    public function saveMany($models, array $properties = array())
+    public function saveMany(array $models, array $properties = array())
     {
         // We will collect the edges returned by save() in an Eloquent Database Collection
         // and return them when done.

--- a/src/Vinelab/NeoEloquent/Eloquent/Relations/OneRelation.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Relations/OneRelation.php
@@ -60,7 +60,7 @@ abstract class OneRelation extends BelongsTo implements RelationInterface {
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Vinelab\NeoEloquent\Eloquent\Edges\Relation
      */
-    public function associate($model, $attributes = array())
+    public function associate(Model $model, $attributes = array())
     {
         /**
          * For associated models we will need to create a unique relationship

--- a/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
@@ -192,7 +192,22 @@ class Grammar extends IlluminateGrammar {
         // @see https://github.com/Vinelab/NeoEloquent/issues/7
         if ( ! is_null($relation)) $labels = 'with_'. $relation .'_'. $labels;
 
-        return mb_strtolower($labels);
+        // patch to fix bug 49.  this downcases only first letter of label which is
+        // compatible with how labels are recased in the rest of the library
+        if (is_array($labels)) {
+            foreach ($labels as $label) {
+                $firstChar = substr($label, 0, 1);
+                $suffix = substr($label, 1, strlen($label) - 1);
+                $label = mb_strtolower($firstChar) . $suffix;
+            }
+        } else {
+            $firstChar = substr($labels, 0, 1);
+            $suffix = substr($labels, 1, strlen($labels) - 1);
+            $labels = mb_strtolower($firstChar) . $suffix;
+        }
+        // the following line is what used to be returned that caused bug 49
+//        return mb_strtolower($labels);
+        return $labels;
     }
 
     /**

--- a/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
@@ -171,10 +171,11 @@ class Grammar extends IlluminateGrammar {
     /**
      * Get a model's name as a Node placeholder
      *
-     * i.e. in "MATCH (user:`User`)"... "user" is what this method returns
+     * Downcases first letter in labels - i.e. in "MATCH (user:`User`)"... "user"
+     * if $relation != null then 'with_' is appended to labels
      *
      * @param  string|array $labels The labels we're choosing from
-     * @param  boolean $related Tells whether this is a related node so that we append a 'with_' to label.
+     * @param  boolean $relation Tells whether this is a related node so that we append a 'with_' to label.
      * @return string
      */
     public function modelAsNode($labels = null, $relation = null)
@@ -194,6 +195,7 @@ class Grammar extends IlluminateGrammar {
 
         // patch to fix bug 49.  this downcases only first letter of label which is
         // compatible with how labels are recased in the rest of the library
+        // @see https://github.com/Vinelab/NeoEloquent/issues/49
         if (is_array($labels)) {
             foreach ($labels as $label) {
                 $firstChar = substr($label, 0, 1);
@@ -205,8 +207,6 @@ class Grammar extends IlluminateGrammar {
             $suffix = substr($labels, 1, strlen($labels) - 1);
             $labels = mb_strtolower($firstChar) . $suffix;
         }
-        // the following line is what used to be returned that caused bug 49
-//        return mb_strtolower($labels);
         return $labels;
     }
 


### PR DESCRIPTION
I changed Grammar::modelAsNode() so that it now downcases only the first character of labels rather than downcasing the entire string.  I believe that this is the correct casing, please let me know if I am wrong.