### PR TITLE
Fixed syntax error when building namespaced relation label

### DIFF
--- a/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
@@ -84,7 +84,7 @@ class Grammar extends IlluminateGrammar {
      */
     public function prepareRelation($relation, $related)
     {
-        return "rel_". mb_strtolower($relation) .'_'. $related .":{$relation}";
+        return "`rel_". mb_strtolower($relation) .'_'. $related ."`:`{$relation}`";
     }
 
     /**

--- a/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
+++ b/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
@@ -71,7 +71,7 @@ class GrammarTest extends TestCase {
 
     public function testPreparingRelationName()
     {
-    	$this->assertEquals('rel_posted_post:POSTED', $this->grammar->prepareRelation('POSTED', 'post'));
+    	$this->assertEquals('`rel_posted_post`:`POSTED`', $this->grammar->prepareRelation('POSTED', 'post'));
     }
 
     public function testNormalizingLabels()


### PR DESCRIPTION
I was getting a syntax error when attempting a simple query using namespaced Models and a one-to-one relationship. Here is the basic code containing the query:

```
use App\User;
$app->get('user/{id}', function ($id) use ($app) {
    return User::with('phone')->find($id);
});

```

And here is the error that was being returned.

```
SyntaxException: Invalid input '\': expected an identifier character, whitespace, '?', relationship types, a length specification, a property map or ']' (line 1, column 37 (offset: 36))
"MATCH (user:`User`), (user)-[rel_app\user_phone:APP\USER]->(phone:`Phone`) WHERE id(user) IN [3] RETURN phone, user"
```

It just seems as though backticks need to be added to escape the special characters.