### PR TITLE
Migrations in v1.2.5 on Laravel 5.1 were broken due to an array_diff …

### DIFF
--- a/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
+++ b/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
@@ -47,7 +47,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
      */
     public function getRan()
     {
-        return $this->model->all()->lists('migration');
+        return $this->model->all()->lists('migration')->toArray();
     }
 
     /**


### PR DESCRIPTION
…call in Laravel's Migrator.php. By calling ->toArray() on the Collection returned by NeoEloquent's getRan(), the issue seems to be resolved.

Please implement this changeset as migrations aren't working in Laravel 5.1.