### PR TITLE
2.0.0 alpha softdelete fixes pr

### DIFF
--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateCommand.php
@@ -11,12 +11,12 @@ class MigrateCommand extends BaseCommand
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $name = 'neo4j:migrate';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $description = 'Run the database migrations';
 
@@ -45,7 +45,7 @@ class MigrateCommand extends BaseCommand
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fire()
     {
@@ -79,7 +79,7 @@ class MigrateCommand extends BaseCommand
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getOptions()
     {

--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateMakeCommand.php
@@ -10,12 +10,12 @@ use Vinelab\NeoEloquent\Migrations\MigrationCreator;
 class MigrateMakeCommand extends BaseCommand
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $name = 'neo4j:make:migration';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $description = 'Create a new migration file';
 
@@ -50,7 +50,7 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fire()
     {
@@ -94,7 +94,7 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getArguments()
     {
@@ -104,7 +104,7 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getOptions()
     {

--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateRefreshCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateRefreshCommand.php
@@ -11,17 +11,17 @@ class MigrateRefreshCommand extends Command
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $name = 'neo4j:migrate:refresh';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $description = 'Reset and re-run all migrations';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fire()
     {
@@ -72,7 +72,7 @@ class MigrateRefreshCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getOptions()
     {

--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateResetCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateResetCommand.php
@@ -12,12 +12,12 @@ class MigrateResetCommand extends Command
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $name = 'neo4j:migrate:reset';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $description = 'Rollback all database migrations';
 
@@ -39,7 +39,7 @@ class MigrateResetCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fire()
     {
@@ -68,7 +68,7 @@ class MigrateResetCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getOptions()
     {

--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateRollbackCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateRollbackCommand.php
@@ -12,12 +12,12 @@ class MigrateRollbackCommand extends Command
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $name = 'neo4j:migrate:rollback';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $description = 'Rollback the last database migration';
 
@@ -41,7 +41,7 @@ class MigrateRollbackCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fire()
     {
@@ -64,7 +64,7 @@ class MigrateRollbackCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getOptions()
     {

--- a/src/Vinelab/NeoEloquent/Eloquent/Builder.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Builder.php
@@ -40,14 +40,16 @@ class Builder extends IlluminateBuilder
         // so we cast it anyways.
 
         if (is_array($id)) {
-            return $this->findMany(array_map(function ($id) { return (int) $id; }, $id), $properties);
+            return $this->findMany(array_map(function ($id) {
+                        return (int) $id;
+                    }, $id), $properties);
         } else {
             $id = (int) $id;
         }
 
         if ($this->model->getKeyName() === 'id') {
             // ids are treated differently in neo4j so we have to adapt the query to them.
-            $this->query->where($this->model->getKeyName() . '('. $this->query->modelAsNode() .')', '=', $id);
+            $this->query->where($this->model->getKeyName().'('.$this->query->modelAsNode().')', '=', $id);
         } else {
             $this->query->where($this->model->getKeyName(), '=', $id);
         }
@@ -341,6 +343,7 @@ class Builder extends IlluminateBuilder
      * @param array                     $columns
      *
      * @return array
+     *
      * @deprecated 2.0 using getNodeAttributes instead
      */
     public function getProperties(array $resultColumns, Row $row)
@@ -353,7 +356,6 @@ class Builder extends IlluminateBuilder
         // and each result is either a Node or a single column value
         // so we first extract the returned value and retrieve
         // the attributes according to the result type.
-
         // Only when requesting a single property
         // will we extract the current() row of result.
 
@@ -387,7 +389,6 @@ class Builder extends IlluminateBuilder
             // If the node id is in the columns we need to treat it differently
             // since Neo4j's convenience with node ids will be retrieved as id(n)
             // instead of n.id.
-
             // WARNING: Do this after setting all the attributes to avoid overriding it
             // with a null value or colliding it with something else, some Daenerys dragons maybe ?!
             if (!is_null($columns) && in_array('id', $columns)) {
@@ -650,7 +651,9 @@ class Builder extends IlluminateBuilder
      */
     public function getMorphMutations()
     {
-        return array_filter($this->getMutations(), function ($mutation) { return $this->isMorphMutation($mutation); });
+        return array_filter($this->getMutations(), function ($mutation) {
+            return $this->isMorphMutation($mutation);
+        });
     }
 
     /**
@@ -678,7 +681,7 @@ class Builder extends IlluminateBuilder
             return true;
         });
 
-        return  count($matched) > 1 ? true : false;
+        return count($matched) > 1 ? true : false;
     }
 
     /**
@@ -723,6 +726,10 @@ class Builder extends IlluminateBuilder
              *
              * Which is the result of Post::has('comments', '>=', 10)->get();
              */
+            if (in_array("Vinelab\NeoEloquent\Eloquent\SoftDeletes", class_uses($relation->getRelated()))) {
+                $this->carry([$prefix.'.'.$relation->getRelated()->getQualifiedDeletedAtColumn() => $prefix.'_'.$relation->getRelated()->getQualifiedDeletedAtColumn()]);
+            }
+
             $countPart = $prefix.'_count';
             $this->carry([$relation->getParentNode(), "count($prefix)" => $countPart]);
             $this->whereCarried($countPart, $operator, $count);
@@ -735,12 +742,7 @@ class Builder extends IlluminateBuilder
         // Set the relationship match clause.
         $method = $this->getMatchMethodName($relation);
 
-        $this->$method($relation->getParent(),
-            $relation->getRelated(),
-            $relatedNode,
-            $relation->getForeignKey(),
-            $relation->getLocalKey(),
-            $relation->getParentLocalKeyValue());
+        $this->$method($relation->getParent(), $relation->getRelated(), $relatedNode, $relation->getForeignKey(), $relation->getLocalKey(), $relation->getParentLocalKeyValue());
 
         // Prefix all the columns with the relation's node placeholder in the query
         // and merge the queries that needs to be merged.
@@ -810,8 +812,7 @@ class Builder extends IlluminateBuilder
             // this is probably a One-To-One relationship or the dev decided not to add
             // multiple records as relations so we'll wrap it up in an array.
             if (
-                (!is_array($values) || Helpers::isAssocArray($values) || $values instanceof Model)
-                && !($values instanceof Collection)
+                (!is_array($values) || Helpers::isAssocArray($values) || $values instanceof Model) && !($values instanceof Collection)
             ) {
                 $values = [$values];
             }
@@ -873,7 +874,6 @@ class Builder extends IlluminateBuilder
         // We need to get the attributes of each $value from $values into
         // an instance of the related model so that we make sure that it goes
         // through the $fillable filter pipeline.
-
         // This adds support for having model instances mixed with values, so whenever
         // we encounter a Model we take it as our instance
         if ($attributes instanceof Model) {
@@ -917,8 +917,13 @@ class Builder extends IlluminateBuilder
     {
         if (is_array($query->getQuery()->wheres)) {
             $query->getQuery()->wheres = array_map(function ($where) use ($prefix) {
-                $column = $where['column'];
-                $where['column'] = ($this->isId($column)) ? $column : $prefix.'.'.$column;
+                if ($where['type'] === 'SoftDeleted') {
+                    $where['placeholderType'] = 'Relation'; // because relation prefix might not be node label
+                    $column = $where['column'];
+                } else {
+                    $column = $where['column'];
+                    $where['column'] = ($this->isId($column)) ? $column : $prefix.'.'.$column;
+                }
 
                 return $where;
             }, $query->getQuery()->wheres);

--- a/src/Vinelab/NeoEloquent/Eloquent/Model.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Model.php
@@ -5,7 +5,6 @@ namespace Vinelab\NeoEloquent\Eloquent;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as IlluminateModel;
 use Vinelab\NeoEloquent\Eloquent\Builder as EloquentBuilder;
-use Vinelab\NeoEloquent\Eloquent\Model;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsTo;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsToMany;
 use Vinelab\NeoEloquent\Eloquent\Relations\HasMany;
@@ -533,7 +532,7 @@ abstract class Model extends IlluminateModel
 
             foreach ($related as $model) {
                 // we will fire model events on actual models, however attached models using IDs will not be considered.
-                if ($model instanceof Model) {
+                if ($model instanceof self) {
                     if (!$model->exists && $model->fireModelEvent('creating') === false) {
                         return false;
                     }

--- a/src/Vinelab/NeoEloquent/Eloquent/SoftDeletes.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/SoftDeletes.php
@@ -17,4 +17,146 @@ trait SoftDeletes
     {
         return $this->getDeletedAtColumn();
     }
+    /**
+     * Indicates if the model is currently force deleting.
+     *
+     * @var bool
+     */
+    protected $forceDeleting = false;
+
+    /**
+     * Boot the soft deleting trait for a model.
+     */
+    public static function bootSoftDeletes()
+    {
+        static::addGlobalScope(new SoftDeletingScope());
+    }
+
+    /**
+     * Force a hard delete on a soft deleted model.
+     */
+    public function forceDelete()
+    {
+        $this->forceDeleting = true;
+
+        $this->delete();
+
+        $this->forceDeleting = false;
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     */
+    protected function performDeleteOnModel()
+    {
+        if ($this->forceDeleting) {
+            return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+        }
+
+        return $this->runSoftDelete();
+    }
+
+    /**
+     * Perform the actual delete query on this model instance.
+     */
+    protected function runSoftDelete()
+    {
+        $query = $this->newQuery()->where($this->getKeyName(), $this->getKey());
+
+        $this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
+
+        $query->update([$this->getDeletedAtColumn() => $this->fromDateTime($time)]);
+    }
+
+    /**
+     * Restore a soft-deleted model instance.
+     *
+     * @return bool|null
+     */
+    public function restore()
+    {
+        // If the restoring event does not return false, we will proceed with this
+        // restore operation. Otherwise, we bail out so the developer will stop
+        // the restore totally. We will clear the deleted timestamp and save.
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getDeletedAtColumn()} = null;
+
+        // Once we have saved the model, we will fire the "restored" event so this
+        // developer will do anything they need to after a restore operation is
+        // totally finished. Then we will return the result of the save call.
+        $this->exists = true;
+
+        $result = $this->save();
+
+        $this->fireModelEvent('restored', false);
+
+        return $result;
+    }
+
+    /**
+     * Determine if the model instance has been soft-deleted.
+     *
+     * @return bool
+     */
+    public function trashed()
+    {
+        return !is_null($this->{$this->getDeletedAtColumn()});
+    }
+
+    /**
+     * Get a new query builder that includes soft deletes.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public static function withTrashed()
+    {
+        return (new static())->newQueryWithoutScope(new SoftDeletingScope());
+    }
+
+    /**
+     * Get a new query builder that only includes soft deletes.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public static function onlyTrashed()
+    {
+        $instance = new static();
+
+        $column = $instance->getQualifiedDeletedAtColumn();
+
+        return $instance->newQueryWithoutScope(new SoftDeletingScope())->whereNotNull($column);
+    }
+
+    /**
+     * Register a restoring model event with the dispatcher.
+     *
+     * @param \Closure|string $callback
+     */
+    public static function restoring($callback)
+    {
+        static::registerModelEvent('restoring', $callback);
+    }
+
+    /**
+     * Register a restored model event with the dispatcher.
+     *
+     * @param \Closure|string $callback
+     */
+    public static function restored($callback)
+    {
+        static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Get the name of the "deleted at" column.
+     *
+     * @return string
+     */
+    public function getDeletedAtColumn()
+    {
+        return defined('static::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
+    }
 }

--- a/src/Vinelab/NeoEloquent/Eloquent/SoftDeletingScope.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/SoftDeletingScope.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Vinelab\NeoEloquent\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder as IlluminateBuilder;
+use Illuminate\Database\Eloquent\Model as IlluminateModel;
+
+class SoftDeletingScope implements \Illuminate\Database\Eloquent\ScopeInterface
+{
+    /**
+     * All of the extensions to be added to the builder.
+     *
+     * @var array
+     */
+    protected $extensions = ['ForceDelete', 'Restore', 'WithTrashed', 'OnlyTrashed'];
+
+    /**
+     * Apply the scope to a given Eloquent query builder by adding a WHERE checking that the deleted
+     * at column IS NULL.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param \Illuminate\Database\Eloquent\Model   $model
+     */
+    public function apply(IlluminateBuilder $builder, IlluminateModel $model)
+    {
+        $builder->whereSoftDeleted('node', $builder->getQuery()->modelAsNode($model->getTable()), $model->getQualifiedDeletedAtColumn(), 'and', false);
+        $this->extend($builder);
+    }
+
+    /**
+     * Remove the scope from the given Eloquent query builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     * @param \Illuminate\Database\Eloquent\Model   $model
+     */
+    public function remove(IlluminateBuilder $builder, IlluminateModel $model)
+    {
+        $column = $model->getQualifiedDeletedAtColumn();
+
+        $query = $builder->getQuery();
+
+        $query->wheres = collect($query->wheres)->reject(function ($where) use ($column) {
+                return $this->isSoftDeleteConstraint($where, $column);
+            })->values()->all();
+    }
+
+    /**
+     * Extend the query builder with the needed functions.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     */
+    public function extend(IlluminateBuilder $builder)
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+
+        $builder->onDelete(function (Builder $builder) {
+            $column = $this->getDeletedAtColumn($builder);
+
+            return $builder->update([
+                    $column => $builder->getModel()->freshTimestampString(),
+            ]);
+        });
+    }
+
+    /**
+     * Get the "deleted at" column for the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     *
+     * @return string
+     */
+    protected function getDeletedAtColumn(IlluminateBuilder $builder)
+    {
+        if (count($builder->getQuery()->joins) > 0) {
+            return $builder->getModel()->getQualifiedDeletedAtColumn();
+        } else {
+            return $builder->getModel()->getDeletedAtColumn();
+        }
+    }
+
+    /**
+     * Add the force delete extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     */
+    protected function addForceDelete(IlluminateBuilder $builder)
+    {
+        $builder->macro('forceDelete', function (Builder $builder) {
+            return $builder->getQuery()->delete();
+        });
+    }
+
+    /**
+     * Add the restore extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     */
+    protected function addRestore(IlluminateBuilder $builder)
+    {
+        $builder->macro('restore', function (Builder $builder) {
+            $builder->withTrashed();
+
+            return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);
+        });
+    }
+
+    /**
+     * Add the with-trashed extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     */
+    protected function addWithTrashed(IlluminateBuilder $builder)
+    {
+        $builder->macro('withTrashed', function (Builder $builder) {
+            $this->remove($builder, $builder->getModel());
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Add the only-trashed extension to the builder.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $builder
+     */
+    protected function addOnlyTrashed(IlluminateBuilder $builder)
+    {
+        $builder->macro('onlyTrashed', function (Builder $builder) {
+            $model = $builder->getModel();
+
+            $this->remove($builder, $model);
+
+            $builder->getQuery()->whereNotNull($model->getQualifiedDeletedAtColumn());
+
+            return $builder;
+        });
+    }
+
+    /**
+     * Determine if the given where clause is a soft delete constraint.
+     *
+     * @param array  $where
+     * @param string $column
+     *
+     * @return bool
+     */
+    protected function isSoftDeleteConstraint(array $where, $column)
+    {
+        return $where['type'] == 'SoftDeleted' && $where['column'] == $column;
+    }
+}

--- a/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
+++ b/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
@@ -16,19 +16,19 @@ use Vinelab\NeoEloquent\Console\Migrations\MigrateRollbackCommand;
 class MigrationServiceProvider extends ServiceProvider
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $defer = true;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function boot()
     {
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function register()
     {
@@ -177,7 +177,7 @@ class MigrationServiceProvider extends ServiceProvider
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function provides()
     {

--- a/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
+++ b/src/Vinelab/NeoEloquent/Migrations/DatabaseMigrationRepository.php
@@ -43,7 +43,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRan()
     {
@@ -51,7 +51,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLast()
     {
@@ -59,7 +59,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function log($file, $batch)
     {
@@ -69,7 +69,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function delete($migration)
     {
@@ -77,7 +77,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getNextBatchNumber()
     {
@@ -85,7 +85,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLastBatchNumber()
     {
@@ -93,7 +93,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createRepository()
     {
@@ -101,7 +101,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function repositoryExists()
     {
@@ -139,7 +139,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setSource($name)
     {

--- a/src/Vinelab/NeoEloquent/Migrations/MigrationCreator.php
+++ b/src/Vinelab/NeoEloquent/Migrations/MigrationCreator.php
@@ -30,7 +30,7 @@ class MigrationCreator extends IlluminateMigrationCreator
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getStubPath()
     {

--- a/src/Vinelab/NeoEloquent/Migrations/MigrationModel.php
+++ b/src/Vinelab/NeoEloquent/Migrations/MigrationModel.php
@@ -7,12 +7,12 @@ use Vinelab\NeoEloquent\Eloquent\Model as NeoEloquent;
 class MigrationModel extends NeoEloquent
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $label = 'NeoEloquentMigration';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $fillable = array(
         'migration',
@@ -20,7 +20,7 @@ class MigrationModel extends NeoEloquent
     );
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected $guarded = array();
 }

--- a/src/Vinelab/NeoEloquent/Query/Builder.php
+++ b/src/Vinelab/NeoEloquent/Query/Builder.php
@@ -62,12 +62,12 @@ class Builder extends IlluminateQueryBuilder
      * @var array
      */
     protected $operators = array(
-        '+', '-', '*', '/', '%', '^',    // Mathematical
+        '+', '-', '*', '/', '%', '^', // Mathematical
         '=', '<>', '<', '>', '<=', '>=', // Comparison
         'is null', 'is not null',
-        'and', 'or', 'xor', 'not',       // Boolean
-        'in', '[x]', '[x .. y]',         // Collection
-        '=~',                             // Regular Expression
+        'and', 'or', 'xor', 'not', // Boolean
+        'in', '[x]', '[x .. y]', // Collection
+        '=~', // Regular Expression
     );
 
     /**
@@ -216,10 +216,10 @@ class Builder extends IlluminateQueryBuilder
         // received when the method was called and pass it into the nested where.
         if (is_array($column)) {
             return $this->whereNested(function (IlluminateQueryBuilder $query) use ($column) {
-                foreach ($column as $key => $value) {
-                    $query->where($key, '=', $value);
-                }
-            }, $boolean);
+                    foreach ($column as $key => $value) {
+                        $query->where($key, '=', $value);
+                    }
+                }, $boolean);
         }
 
         if (func_num_args() == 2) {
@@ -320,8 +320,8 @@ class Builder extends IlluminateQueryBuilder
     {
         if (is_array($this->wheres)) {
             return count(array_filter($this->wheres, function ($where) use ($column) {
-                return $where['column'] == $column;
-            }));
+                    return $where['column'] == $column;
+                }));
         }
     }
 
@@ -408,6 +408,34 @@ class Builder extends IlluminateQueryBuilder
         $binding = $this->prepareBindingColumn($column);
 
         $this->wheres[] = compact('type', 'column', 'boolean', 'binding');
+
+        return $this;
+    }
+
+    /**
+     * WhereSoftDeleted is a special kind of WHERE clause used to include or exclude soft deleted models.
+     * It is similar to whereNull, but needs more arguments because it is called in SoftDeletingScope
+     * and must record additional information needed later in the compilation process.  In particular
+     * at the time that the SoftDeletingScope is applied we cannot yet tell whether the node placeholder
+     * based on the model's labels will be used ($placeholderType = 'node'), or whether we will need to use a placeholder based
+     * on a relation name ($placeholderType = 'relation'). 
+     * 
+     * @param string $placeholderType
+     * @param string $nodePlaceholder placeholder to be used as prefix to qualified deleted column
+     * @param string $column          qualified deleted at column
+     * @param string $boolean         same as with whereNull
+     * @param string $not             if false soft deleted models will not be returned, if true only soft deleted models will be returned
+     *
+     * @return \Vinelab\NeoEloquent\Query\Builder
+     */
+    public function WhereSoftDeleted($placeholderType, $nodePlaceholder, $column, $boolean = 'and', $not = false)
+    {
+        $type = 'SoftDeleted';
+        $operator = $not ? 'IS NOT NULL' : 'IS NULL';
+        $placeholder = $nodePlaceholder;
+        $placeholderType = $placeholderType;
+        $binding = null;
+        $this->wheres[] = compact('type', 'placeholderType', 'placeholder', 'column', 'operator', 'boolean', 'binding');
 
         return $this;
     }
@@ -704,7 +732,7 @@ class Builder extends IlluminateQueryBuilder
     {
         $this->aggregate = array_merge([
             'label' => $this->from,
-        ], compact('function', 'columns', 'percentile'));
+            ], compact('function', 'columns', 'percentile'));
 
         $previousColumns = $this->columns;
 
@@ -800,6 +828,16 @@ class Builder extends IlluminateQueryBuilder
         $this->bindings['where'] = array_merge_recursive($this->bindings['where'], (array) $bindings);
     }
 
+    /**
+     * Merge an array of with clauses.
+     *
+     * @param array $with
+     */
+    public function mergeWith($with)
+    {
+        $this->with = array_merge((array) $this->with, (array) $with);
+    }
+
     public function wrap($property)
     {
         return $this->grammar->getIdReplacement($property);
@@ -832,13 +870,13 @@ class Builder extends IlluminateQueryBuilder
 
         return $value;
     }
-
     /*
      * Add/Drop labels
      * @param $labels array array of strings(labels)
      * @param $operation string 'add' or 'drop'
      * @return bool true if success, otherwise false
      */
+
     public function updateLabels($labels, $operation = 'add')
     {
         $cypher = $this->grammar->compileUpdateLabels($this, $labels, $operation);

--- a/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
@@ -161,7 +161,7 @@ class CypherGrammar extends Grammar
         $property = $property == 'id' ? 'id('.$parent['node'].')' : $parent['node'].'.'.$property;
 
         return '('.$parent['node'].$parentLabels.'), '
-                .$this->craftRelation($parent['node'], $relationshipLabel, $related['node'], $relatedLabels, $direction);
+            .$this->craftRelation($parent['node'], $relationshipLabel, $related['node'], $relatedLabels, $direction);
     }
 
     /**
@@ -188,7 +188,7 @@ class CypherGrammar extends Grammar
         $property = $property == 'id' ? 'id('.$parent['node'].')' : $parent['node'].'.'.$property;
 
         return '('.$parent['node'].$parentLabels.'), '
-                .$this->craftRelation($parent['node'], 'r', $relatedNode, '', $direction);
+            .$this->craftRelation($parent['node'], 'r', $relatedNode, '', $direction);
     }
 
     /**
@@ -219,19 +219,18 @@ class CypherGrammar extends Grammar
         switch (strtolower($direction)) {
             case 'out':
                 $relation = '(%s)-[%s]->%s';
-            break;
+                break;
 
             case 'in':
                 $relation = '(%s)<-[%s]-%s';
-            break;
+                break;
 
             default:
                 $relation = '(%s)-[%s]-%s';
-            break;
+                break;
         }
 
-        return ($bare) ? sprintf($relation, $parentNode, $relationLabel, $relatedNode)
-            : sprintf($relation, $parentNode, $relationLabel, '('.$relatedNode.$relatedLabels.')');
+        return ($bare) ? sprintf($relation, $parentNode, $relationLabel, $relatedNode) : sprintf($relation, $parentNode, $relationLabel, '('.$relatedNode.$relatedLabels.')');
     }
 
     /**
@@ -312,6 +311,28 @@ class CypherGrammar extends Grammar
         $value = $this->parameter($where);
 
         return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+    }
+
+    /**
+     * The where clause that excludes soft deleted models, or selects only soft deleted models
+     * is added when the soft deleting scope is applied.  This is too early in the compilation
+     * process to know whether any WITH clauses will appear in final output.
+     * This function formats the soft delete WHERE clause correctly in either case.
+     * 
+     * @param Builder $query
+     * @param array   $where
+     *
+     * @return string
+     */
+    protected function WHERESoftDeleted(Builder $query, $where)
+    {
+        if (empty($query->with)) {
+            $cypher = $where['placeholder'].'.'.$where['column'].' '.$where['operator'].' ';
+        } else {
+            $cypher = $where['placeholder'].'_'.$where['column'].' '.$where['operator'].' ';
+        }
+
+        return $cypher;
     }
 
     /**
@@ -417,8 +438,8 @@ class CypherGrammar extends Grammar
     public function compileOrders(Builder $query, $orders)
     {
         return 'ORDER BY '.implode(', ', array_map(function ($order) {
-                return $this->wrap($order['column']).' '.mb_strtoupper($order['direction']);
-        }, $orders));
+                    return $this->wrap($order['column']).' '.mb_strtoupper($order['direction']);
+                }, $orders));
     }
 
     /**
@@ -485,7 +506,7 @@ class CypherGrammar extends Grammar
     public function columnsFromValues(array $values, $updating = false)
     {
         $columns = [];
-         // Each one of the columns in the update statements needs to be wrapped in the
+        // Each one of the columns in the update statements needs to be wrapped in the
         // keyword identifiers, also a place-holder needs to be created for each of
         // the values in the list of bindings so we can make the sets statements.
 
@@ -633,7 +654,7 @@ class CypherGrammar extends Grammar
 
         $query = "MATCH ($startNode$startLabel)";
 
-         // we account for no-end relationships.
+        // we account for no-end relationships.
         if (isset($attributes['end'])) {
             $endKey = $attributes['end']['id']['key'];
             $endNode = 'rel_'.$this->modelAsNode($attributes['label']);
@@ -686,12 +707,7 @@ class CypherGrammar extends Grammar
         }
 
         $query = $this->craftRelation(
-            $startNode,
-            'r:'.$attributes['label'],
-            '('.$endNode.')',
-            $endLabel,
-            $attributes['direction'],
-            true
+            $startNode, 'r:'.$attributes['label'], '('.$endNode.')', $endLabel, $attributes['direction'], true
         );
 
         $properties = $attributes['properties'];
@@ -753,14 +769,13 @@ class CypherGrammar extends Grammar
         $model = $create['model'];
         $related = $create['related'];
         $identifier = true; // indicates that we this entity requires an identifier for prepareEntity.
-
         // Prepare the parent model as a query entity with an identifier to be
         // later used when relating with the rest of the models, something like:
         // (post:`Post` {title: '..', body: '...'})
         $entity = $this->prepareEntity([
             'label' => $model['label'],
             'bindings' => $model['attributes'],
-        ], $identifier);
+            ], $identifier);
 
         $parentNode = $this->modelAsNode($model['label']);
 
@@ -794,12 +809,7 @@ class CypherGrammar extends Grammar
                 $createdIdsToReturn[] = $identifier;
                 // get a relation cypher.
                 $relations[] = $this->craftRelation(
-                    $parentNode,
-                    ':'.$relation['type'],
-                    $this->prepareEntity(compact('label', 'bindings'), $identifier),
-                    $this->modelAsNode($label),
-                    $relation['direction'],
-                    $bare
+                    $parentNode, ':'.$relation['type'], $this->prepareEntity(compact('label', 'bindings'), $identifier), $this->modelAsNode($label), $relation['direction'], $bare
                 );
             }
 
@@ -827,12 +837,7 @@ class CypherGrammar extends Grammar
                 }
 
                 $attachments['relations'][] = $this->craftRelation(
-                    $parentNode,
-                    ':'.$relation['type'],
-                    "($identifier)",
-                    $nodeLabel,
-                    $relation['direction'],
-                    $bare
+                    $parentNode, ':'.$relation['type'], "($identifier)", $nodeLabel, $relation['direction'], $bare
                 );
             }
         }
@@ -850,7 +855,7 @@ class CypherGrammar extends Grammar
             $cypher .= " WITH $parentNode";
 
             if (!empty($createdIdsToReturn)) {
-                $cypher  .= ', '.implode(', ', $createdIdsToReturn);
+                $cypher .= ', '.implode(', ', $createdIdsToReturn);
             }
 
             // MATCH the related nodes that we are attaching.
@@ -880,8 +885,8 @@ class CypherGrammar extends Grammar
 
         // We need to format the columns to be in the form of n.property unless it is a *.
         $columns = implode(', ', array_map(function ($column) use ($node) {
-            return $column == '*' ? $column : "$node.$column";
-        }, $aggregate['columns']));
+                return $column == '*' ? $column : "$node.$column";
+            }, $aggregate['columns']));
 
         if (!is_null($aggregate['percentile'])) {
             $percentile = $aggregate['percentile'];

--- a/tests/config/database.php
+++ b/tests/config/database.php
@@ -8,18 +8,14 @@ return [
 
         'neo4j' => [
             'driver' => 'neo4j',
-            'host' => 'dev',
-            'port' => 7575,
+            'host' => 'localhost',
+            'port' => 7474,
             'username' => 'neo4j',
             'password' => 'test',
         ],
 
         'default' => [
             'driver' => 'neo4j',
-            'host' => 'dev',
-            'port' => 7575,
-            'username' => 'neo4j',
-            'password' => 'test',
         ],
     ],
 ];

--- a/tests/functional/BelongsToRelationTest.php
+++ b/tests/functional/BelongsToRelationTest.php
@@ -247,5 +247,4 @@ class BelongsToRelationTest extends TestCase
         $remainingUser = User::find($user->getKey());
         $this->assertEquals($user->toArray(), $remainingUser->toArray());
     }
-
 }

--- a/tests/functional/ModelEventsTest.php
+++ b/tests/functional/ModelEventsTest.php
@@ -300,7 +300,7 @@ class OBOne extends Model
         });
 
         static::$dispatcher = $dispatcher;
-        OBOne::observe(new UserObserver());
+        self::observe(new UserObserver());
     }
 }
 


### PR DESCRIPTION
I ​_finally_​ got working an approach to handling soft deletes that I like.  Soft deletes were not previously working with anything requiring a WITH statement.  I fixed that by overriding the SoftDeletingScope and injecting a special WHERE clause that later on in the compilation adds the correct WITH clauses and WHERE format. (if and only if the compiled statement would have WITH clauses not related to soft deletes)

Following example wants to retrieve posts with 10 soft deletable comments that are not soft deleted.

before:
MATCH (post:`Post`), (post)-[rel_comment_del_commentdel:COMMENT_DEL]->(commentdel:`CommentDel`) WITH post, count(commentdel) AS commentdel_count WHERE commentdel_count = 10 and commentdel.deleted_at IS NULL  RETURN post

Error is that commentdel.deleted_at is not passed through the WITH

after:
MATCH (post:`Post`), (post)-[rel_comment_del_commentdel:COMMENT_DEL]->(commentdel:`CommentDel`) WITH commentdel.deleted_at AS commentdel_deleted_at, post, count(commentdel) AS commentdel_count WHERE commentdel_count = 10 and commentdel_deleted_at IS NULL  RETURN post