### PR TITLE
fix issue #134

### DIFF
--- a/src/Vinelab/NeoEloquent/Connection.php
+++ b/src/Vinelab/NeoEloquent/Connection.php
@@ -305,6 +305,18 @@ class Connection extends IlluminateConnection {
                 if ($property == 'id') $property = $grammar->getIdReplacement($property);
 
                 $prepared[$property] = $real;
+
+                if(isset($prepared['name']))
+                {   
+                    $prepared[$property] = array_values($binding);
+                    $values = $prepared['name'];
+                    if(sizeof($values)>1)
+                    {
+                        foreach ($values as $key => $value) {
+                            $prepared["name".$key] = $value;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/CypherGrammar.php
@@ -301,6 +301,14 @@ class CypherGrammar extends Grammar {
             $cypher[] = $where['boolean'].' '.$this->$method($query, $where);
         }
 
+        //add integer to the name variable
+        if(sizeof($cypher)>1)
+        {   
+            foreach ($cypher as $key => $value) {
+                $cypher[$key] = str_replace('{name}', "{name$key}", $cypher[$key]);
+            } 
+        }
+
         // If we actually have some where clauses, we will strip off the first boolean
         // operator, which is added by the query builders for convenience so we can
         // avoid checking for the first clauses in each of the compilers methods.

--- a/tests/functional/QueryingRelationsTest.php
+++ b/tests/functional/QueryingRelationsTest.php
@@ -668,6 +668,27 @@ class QueryingRelationsTest extends TestCase {
         $this->assertEquals('theTag', $tags[0]['title']);
     }
 
+    public function testQueryingParentWithMultipleWhereHasUsingName()
+    {
+        $user = new User();
+        $user1 = User::create(['name'=>'bob']);
+        $user2 = User::create(['name'=>'zack']);
+
+        $book = Book::create(['name'=>'book1']);
+        $disk = Disk::create(['name' => 'disk1']);
+
+        $user1->books()->save($book);
+        $user1->disks()->save($disk);
+
+        $user = $user->whereHas('books',function($query){
+                            $query->where('name','book1');
+                        })
+                     ->whereHas('disks', function($query){
+                            $query->where('name','disk1');
+                        })->get();
+        $this->assertEquals('bob', $user[0]->name);
+    }
+
 }
 
 class User extends Model {
@@ -694,6 +715,40 @@ class User extends Model {
     public function organization()
     {
         return $this->belongsTo('Vinelab\NeoEloquent\Tests\Functional\QueryingRelations\Organization', 'MEMBER_OF');
+    }
+
+    public function books()
+    {
+        return $this->hasMany('Vinelab\NeoEloquent\Tests\Functional\QueryingRelations\Book', 'HAS');
+    }
+
+    public function disks()
+    {
+        return $this->hasMany('Vinelab\NeoEloquent\Tests\Functional\QueryingRelations\Disk', 'HAS');
+    }
+}
+
+class Book extends Model  {
+
+    protected $label = 'Book';
+
+    protected $fillable = ['name'];
+
+    public function user()
+    {
+        return $this->belongsTo('Vinelab\NeoEloquent\Tests\Functional\QueryingRelations\User', 'HAS');
+    }
+}
+
+class Disk extends Model {
+
+    protected $label = 'Disk';
+
+    protected $fillable = ['name'];
+
+    public function user()
+    {
+        return $this->belongsTo('Vinelab\NeoEloquent\Tests\Functional\QueryingRelations\User', 'HAS');
     }
 }
 


### PR DESCRIPTION
This issue appears when querying multiple whereHas with the same attribute name which will create a conflict in the cypher query because both query parameters will have the same attribute name.

I fixed this issue by adding an integer at the end of each attribute name.