### PR TITLE
Switch to neo4jphp that is compatible with PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "5.1.*",
         "illuminate/database": "5.1.*",
         "illuminate/pagination": "5.1.*",
-        "vinelab/neo4jphp": "0.1.*",
+        "heydavid713/neo4jphp": "0.1.*",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {

--- a/src/Vinelab/NeoEloquent/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Vinelab/NeoEloquent/Console/Migrations/MigrateMakeCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace Vinelab\NeoEloquent\Console\Migrations;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Vinelab\NeoEloquent\Migrations\MigrationCreator;

--- a/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
+++ b/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
@@ -190,7 +190,7 @@ class MigrationServiceProvider extends ServiceProvider {
 
             $packagePath = $app['path.base'].'/vendor';
 
-            $composer = $app->make('Illuminate\Foundation\Composer');
+            $composer = $app->make('Illuminate\Support\Composer');
 
             return new MigrateMakeCommand($creator, $composer, $packagePath);
         });

--- a/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
+++ b/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
@@ -75,7 +75,7 @@ class MigrationServiceProvider extends ServiceProvider {
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->bindShared('neoeloquent.migrator', function($app) {
+        $this->app->singleton('neoeloquent.migrator', function($app) {
             $repository = $app['neoeloquent.migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files']);

--- a/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
+++ b/src/Vinelab/NeoEloquent/MigrationServiceProvider.php
@@ -47,7 +47,7 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerRepository()
     {
-        $this->app->bindShared('neoeloquent.migration.repository', function($app)
+        $this->app->singleton('neoeloquent.migration.repository', function($app)
         {
             $model = new MigrationModel;
 
@@ -125,7 +125,7 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerMigrateCommand()
     {
-        $this->app->bindShared('command.neoeloquent.migrate', function($app) {
+        $this->app->singleton('command.neoeloquent.migrate', function($app) {
             $packagePath = $app['path.base'].'/vendor';
 
             return new MigrateCommand($app['neoeloquent.migrator'], $packagePath);
@@ -139,7 +139,7 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->bindShared('command.neoeloquent.migrate.rollback', function($app)
+        $this->app->singleton('command.neoeloquent.migrate.rollback', function($app)
         {
             return new MigrateRollbackCommand($app['neoeloquent.migrator']);
         });
@@ -152,7 +152,7 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->bindShared('command.neoeloquent.migrate.reset', function($app)
+        $this->app->singleton('command.neoeloquent.migrate.reset', function($app)
         {
             return new MigrateResetCommand($app['neoeloquent.migrator']);
         });
@@ -165,7 +165,7 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->bindShared('command.neoeloquent.migrate.refresh', function($app)
+        $this->app->singleton('command.neoeloquent.migrate.refresh', function($app)
         {
             return new MigrateRefreshCommand;
         });
@@ -178,11 +178,11 @@ class MigrationServiceProvider extends ServiceProvider {
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->bindShared('migration.neoeloquent.creator', function($app) {
+        $this->app->singleton('migration.neoeloquent.creator', function($app) {
             return new MigrationCreator($app['files']);
         });
 
-        $this->app->bindShared('command.neoeloquent.migrate.make', function($app) {
+        $this->app->singleton('command.neoeloquent.migrate.make', function($app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.


### PR DESCRIPTION
Fixes #142 with my own fork of neo4jphp. It changes the class name, everything else is intact from the latest change in neo4jphp. Tested working on our project running in PHP 7.