### PR TITLE
UUID Fix for L5.2 Relationships

### DIFF
--- a/src/Vinelab/NeoEloquent/Eloquent/Edges/Delegate.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Edges/Delegate.php
@@ -155,6 +155,7 @@ abstract class Delegate {
         else
         {
             $node->setProperty($model->getKeyName(), $model->getKey());
+            $node->setId($model->id);
         }
 
         return $node;


### PR DESCRIPTION
This is a possible fix for getting relationships working in 5.2 when using uuids. Will be testing this so more locally.