### PR TITLE
fix syntax error when building namespaced relation label

### DIFF
--- a/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
+++ b/src/Vinelab/NeoEloquent/Query/Grammars/Grammar.php
@@ -84,7 +84,7 @@ class Grammar extends IlluminateGrammar {
      */
     public function prepareRelation($relation, $related)
     {
-        return "rel_". mb_strtolower($relation) .'_'. $related .":{$relation}";
+        return "`rel_". mb_strtolower($relation) .'_'. $related ."`:`{$relation}`";
     }
 
     /**

--- a/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
+++ b/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
@@ -73,7 +73,7 @@ class GrammarTest extends TestCase {
 
     public function testPreparingRelationName()
     {
-    	$this->assertEquals('rel_posted_post:POSTED', $this->grammar->prepareRelation('POSTED', 'post'));
+    	$this->assertEquals('`rel_posted_post`:`POSTED`', $this->grammar->prepareRelation('POSTED', 'post'));
     }
 
     public function testNormalizingLabels()


### PR DESCRIPTION
see https://github.com/Vinelab/NeoEloquent/pull/109 for the original fix