### PR TITLE
[1.5-dev] fix Closure error

### DIFF
--- a/src/Frameworks/Laravel/Connection.php
+++ b/src/Frameworks/Laravel/Connection.php
@@ -2,6 +2,7 @@
 
 namespace Vinelab\NeoEloquent\Frameworks\Laravel;
 
+use Closure;
 use Exception;
 use Vinelab\NeoEloquent\QueryException;
 use Vinelab\NeoEloquent\Events\Dispatcher;


### PR DESCRIPTION
As mentioned in #205, there are some errors with 1.5-dev and Laravel 5.3.

This pull request fixes a part of the issue and adds the 'use Closure' instruction.