### PR TITLE
[1.5-dev] Remove laravel forks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,12 @@
     ],
     "require": {
         "php": ">=5.6",
+        "illuminate/container": "5.3.*",
+        "illuminate/contracts": "5.3.*",
         "illuminate/database": "5.3.*",
+        "illuminate/events": "5.3.*",
+        "illuminate/support": "5.3.*",
+        "illuminate/pagination": "5.3.*",
         "vinelab/neoclient": "~3.4",
         "nesbot/carbon": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,6 @@
     ],
     "require": {
         "php": ">=5.6",
-        "vinelab/neoeloquent-support": "5.2.*",
-        "vinelab/neoeloquent-pagination": "5.2.*",
-        "vinelab/neoeloquent-contracts": "5.2.*",
-        "vinelab/neoeloquent-container": "5.2.*",
-        "vinelab/neoeloquent-events": "5.2.*",
         "illuminate/database": "5.3.*",
         "vinelab/neoclient": "~3.4",
         "nesbot/carbon": "~1.0"

--- a/src/Capsule/Manager.php
+++ b/src/Capsule/Manager.php
@@ -3,11 +3,12 @@
 namespace Vinelab\NeoEloquent\Capsule;
 
 use Vinelab\NeoEloquent\Container\Container;
-use Illuminate\Database\DatabaseManager;
 use Vinelab\NeoEloquent\Contracts\Events\Dispatcher;
-use Vinelab\NeoEloquent\Support\Traits\CapsuleManagerTrait;
 use Vinelab\NeoEloquent\Eloquent\Model as Eloquent;
+
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Support\Traits\CapsuleManagerTrait;
 
 class Manager
 {

--- a/src/Capsule/Manager.php
+++ b/src/Capsule/Manager.php
@@ -2,9 +2,9 @@
 
 namespace Vinelab\NeoEloquent\Capsule;
 
-use Vinelab\NeoEloquent\Container\Container;
 use Vinelab\NeoEloquent\Eloquent\Model as Eloquent;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Connectors\ConnectionFactory;

--- a/src/Capsule/Manager.php
+++ b/src/Capsule/Manager.php
@@ -3,9 +3,9 @@
 namespace Vinelab\NeoEloquent\Capsule;
 
 use Vinelab\NeoEloquent\Container\Container;
-use Vinelab\NeoEloquent\Contracts\Events\Dispatcher;
 use Vinelab\NeoEloquent\Eloquent\Model as Eloquent;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Support\Traits\CapsuleManagerTrait;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -19,7 +19,7 @@ use Vinelab\NeoEloquent\Query\Grammars\CypherGrammar;
 use Vinelab\NeoEloquent\Schema\Grammars\CypherGrammar as SchemaGrammar;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
 use Vinelab\NeoEloquent\Query\Processors\Processor;
-use Vinelab\NeoEloquent\Support\Arr;
+use Illuminate\Support\Arr;
 
 class Connection implements ConnectionInterface
 {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -10,15 +10,14 @@ use Neoxygen\NeoClient\Client;
 use Neoxygen\NeoClient\ClientBuilder;
 use Throwable;
 use Vinelab\NeoEloquent\Exceptions\ConstraintViolationException;
-use Vinelab\NeoEloquent\Contracts\Events\Dispatcher;
-use Vinelab\NeoEloquent\Exceptions\ConnectionException;
 use Vinelab\NeoEloquent\Exceptions\Exception as QueryException;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
 use Vinelab\NeoEloquent\Query\Expression;
-use Vinelab\NeoEloquent\Query\Grammars\CypherGrammar;
 use Vinelab\NeoEloquent\Schema\Grammars\CypherGrammar as SchemaGrammar;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
 use Vinelab\NeoEloquent\Query\Processors\Processor;
+
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class Connection implements ConnectionInterface
@@ -58,7 +57,7 @@ class Connection implements ConnectionInterface
     /**
      * The event dispatcher instance.
      *
-     * @var \Vinelab\NeoEloquent\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $events;
 
@@ -205,7 +204,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the event dispatcher used by the connection.
      *
-     * @return \Vinelab\NeoEloquent\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher
      */
     public function getEventDispatcher()
     {
@@ -301,7 +300,7 @@ class Connection implements ConnectionInterface
     /**
      * Set the event dispatcher instance on the connection.
      *
-     * @param \Vinelab\NeoEloquent\Contracts\Events\Dispatcher $events
+     * @param \Illuminate\Contracts\Events\Dispatcher $events
      */
     public function setEventDispatcher(Dispatcher $events)
     {

--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -4,7 +4,8 @@ namespace Vinelab\NeoEloquent\Connectors;
 
 use InvalidArgumentException;
 use Vinelab\NeoEloquent\Connection;
-use Vinelab\NeoEloquent\Contracts\Container\Container;
+
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
 
 class ConnectionFactory

--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -5,7 +5,7 @@ namespace Vinelab\NeoEloquent\Connectors;
 use InvalidArgumentException;
 use Vinelab\NeoEloquent\Connection;
 use Vinelab\NeoEloquent\Contracts\Container\Container;
-use Vinelab\NeoEloquent\Support\Arr;
+use Illuminate\Support\Arr;
 
 class ConnectionFactory
 {

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -12,6 +12,7 @@ use Vinelab\NeoEloquent\Helpers;
 use Vinelab\NeoEloquent\QueryException;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
 use Vinelab\NeoEloquent\Query\Expression;
+
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -1069,7 +1070,7 @@ class Builder
      * @param string   $pageName
      * @param int|null $page
      *
-     * @return \Vinelab\NeoEloquent\Contracts\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -4,7 +4,6 @@ namespace Vinelab\NeoEloquent\Eloquent;
 
 use Closure;
 use Neoxygen\NeoClient\Formatter\Node;
-use Neoxygen\NeoClient\Formatter\Relationship;
 use Neoxygen\NeoClient\Formatter\Result;
 use Vinelab\NeoEloquent\Eloquent\Relations\Relation;
 use Vinelab\NeoEloquent\Eloquent\Relationship as EloquentRelationship;
@@ -15,8 +14,8 @@ use Vinelab\NeoEloquent\Pagination\Paginator;
 use Vinelab\NeoEloquent\QueryException;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
 use Vinelab\NeoEloquent\Query\Expression;
-use Vinelab\NeoEloquent\Support\Arr;
-use Vinelab\NeoEloquent\Support\Str;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class Builder
 {
@@ -273,7 +272,7 @@ class Builder
      * @param string $column
      * @param string $key
      *
-     * @return \Vinelab\NeoEloquent\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function lists($column, $key = null)
     {

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -9,13 +9,13 @@ use Vinelab\NeoEloquent\Eloquent\Relations\Relation;
 use Vinelab\NeoEloquent\Eloquent\Relationship as EloquentRelationship;
 use Vinelab\NeoEloquent\Exceptions\ModelNotFoundException;
 use Vinelab\NeoEloquent\Helpers;
-use Vinelab\NeoEloquent\Pagination\LengthAwarePaginator;
-use Vinelab\NeoEloquent\Pagination\Paginator;
 use Vinelab\NeoEloquent\QueryException;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
 use Vinelab\NeoEloquent\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 
 class Builder
 {
@@ -1109,9 +1109,9 @@ class Builder
      * @param array  $columns
      * @param string $pageName
      *
-     * @return \Vinelab\NeoEloquent\Pagination\Paginator
+     * @return \Illuminate\Pagination\Paginator
      *
-     * @internal param \Vinelab\NeoEloquent\Pagination\Factory $paginator
+     * @internal param \Illuminate\Pagination\Factory $paginator
      */
     public function simplePaginate($perPage = null, $columns = array('*'), $pageName = 'page')
     {

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -175,16 +175,17 @@ class Collection extends BaseCollection
     }
 
     /**
-     * Return only unique items from the collection.
+     * Return only unique items from the collection array.
      *
      * @param string|callable|null $key
+     * @param  bool  $strict
      *
      * @return static
      */
-    public function unique($key = null)
+    public function unique($key = null, $strict = false)
     {
         if (!is_null($key)) {
-            return parent::unique($key);
+            return parent::unique($key, $strict);
         }
 
         return new static(array_values($this->getDictionary()));

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -2,8 +2,8 @@
 
 namespace Vinelab\NeoEloquent\Eloquent;
 
-use Vinelab\NeoEloquent\Support\Arr;
-use Vinelab\NeoEloquent\Support\Collection as BaseCollection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection
 {
@@ -241,7 +241,7 @@ class Collection extends BaseCollection
     /**
      * Get a base Support collection instance from this collection.
      *
-     * @return \Vinelab\NeoEloquent\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public function toBase()
     {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -8,12 +8,6 @@ use ArrayAccess;
 use Carbon\Carbon;
 use LogicException;
 use JsonSerializable;
-use Vinelab\NeoEloquent\Contracts\Support\Jsonable;
-use Vinelab\NeoEloquent\Contracts\Events\Dispatcher;
-use Vinelab\NeoEloquent\Contracts\Support\Arrayable;
-use Vinelab\NeoEloquent\Contracts\Routing\UrlRoutable;
-use Vinelab\NeoEloquent\Contracts\Queue\QueueableEntity;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Vinelab\NeoEloquent\Eloquent\Builder as EloquentBuilder;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsTo;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsToMany;
@@ -26,6 +20,13 @@ use Vinelab\NeoEloquent\Eloquent\Relations\MorphedByOne;
 use Vinelab\NeoEloquent\Eloquent\Relations\Relation;
 use Vinelab\NeoEloquent\Helpers;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -202,7 +203,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The event dispatcher instance.
      *
-     * @var \Vinelab\NeoEloquent\Contracts\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected static $dispatcher;
 
@@ -3405,7 +3406,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the event dispatcher instance.
      *
-     * @return \Vinelab\NeoEloquent\Contracts\Events\Dispatcher
+     * @return \Illuminate\Contracts\Events\Dispatcher
      */
     public static function getEventDispatcher()
     {
@@ -3465,7 +3466,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Set the event dispatcher instance.
      *
-     * @param \Vinelab\NeoEloquent\Contracts\Events\Dispatcher $dispatcher
+     * @param \Illuminate\Contracts\Events\Dispatcher $dispatcher
      */
     public static function setEventDispatcher(Dispatcher $dispatcher)
     {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -14,8 +14,6 @@ use Vinelab\NeoEloquent\Contracts\Support\Arrayable;
 use Vinelab\NeoEloquent\Contracts\Routing\UrlRoutable;
 use Vinelab\NeoEloquent\Contracts\Queue\QueueableEntity;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Vinelab\NeoEloquent\Support\Arr;
-use Vinelab\NeoEloquent\Support\Str;
 use Vinelab\NeoEloquent\Eloquent\Builder as EloquentBuilder;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsTo;
 use Vinelab\NeoEloquent\Eloquent\Relations\BelongsToMany;
@@ -28,6 +26,8 @@ use Vinelab\NeoEloquent\Eloquent\Relations\MorphedByOne;
 use Vinelab\NeoEloquent\Eloquent\Relations\Relation;
 use Vinelab\NeoEloquent\Helpers;
 use Vinelab\NeoEloquent\Query\Builder as QueryBuilder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
@@ -664,7 +664,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param mixed $id
      * @param array $columns
      *
-     * @return \Vinelab\NeoEloquent\Support\Collection|static
+     * @return \Illuminate\Support\Collection|static
      */
     public static function findOrNew($id, $columns = ['*'])
     {

--- a/src/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Eloquent/Relations/HasOneOrMany.php
@@ -7,7 +7,6 @@ use Vinelab\NeoEloquent\Eloquent\Collection;
 use Vinelab\NeoEloquent\Eloquent\Edges\Edge;
 use Vinelab\NeoEloquent\Eloquent\Edges\Finder;
 use Vinelab\NeoEloquent\Eloquent\Model;
-use Vinelab\NeoEloquent\Eloquent\Relationship;
 use Vinelab\NeoEloquent\Exceptions\ModelNotFoundException;
 
 abstract class HasOneOrMany extends Relation implements RelationInterface
@@ -701,7 +700,7 @@ abstract class HasOneOrMany extends Relation implements RelationInterface
      * @param mixed $id
      * @param array $columns
      *
-     * @return \Vinelab\NeoEloquent\Support\Collection|\Illuminate\Database\Eloquent\Model
+     * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
      */
     public function findOrNew($id, $columns = ['*'])
     {

--- a/src/Facade/Neo4jSchema.php
+++ b/src/Facade/Neo4jSchema.php
@@ -2,7 +2,7 @@
 
 namespace Vinelab\NeoEloquent\Facade;
 
-use Vinelab\NeoEloquent\Support\Facades\Facade;
+use Illuminate\Support\Facades\Facade;
 
 /**
  * @see \Vinelab\NeoEloquent\Schema\Builder

--- a/src/Frameworks/Laravel/Connection.php
+++ b/src/Frameworks/Laravel/Connection.php
@@ -4,15 +4,15 @@ namespace Vinelab\NeoEloquent\Frameworks\Laravel;
 
 use Exception;
 use Vinelab\NeoEloquent\QueryException;
-use Vinelab\NeoEloquent\Events\Dispatcher;
 use Vinelab\NeoEloquent\ConnectionInterface;
+
+use Illuminate\Contracts\Events\Dispatcher as IlluminateDispatcher;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Connection as BaseConnection;
-use Vinelab\NeoEloquent\Connection as NeoEloquentConnection;
 use Illuminate\Database\Schema\Grammars\Grammar as SchemaGrammar;
 use Illuminate\Database\QueryException as IlluminateQueryException;
-use Illuminate\Contracts\Events\Dispatcher as IlluminateDispatcher;
+use Illuminate\Events\Dispatcher;
 
 class Connection extends BaseConnection implements ConnectionInterface
 {

--- a/src/Frameworks/Laravel/NeoEloquentServiceProvider52.php
+++ b/src/Frameworks/Laravel/NeoEloquentServiceProvider52.php
@@ -3,10 +3,11 @@
 namespace Vinelab\NeoEloquent\Frameworks\Laravel;
 
 use Vinelab\NeoEloquent\Eloquent\Model;
-use Illuminate\Support\ServiceProvider;
-use Vinelab\NeoEloquent\Events\Dispatcher;
 use Vinelab\NeoEloquent\Schema\Grammars\CypherGrammar;
 use Vinelab\NeoEloquent\Connection as NeoEloquentConnection;
+
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
 
 class NeoEloquentServiceProvider52 extends ServiceProvider
 {

--- a/src/MigrationServiceProvider.php
+++ b/src/MigrationServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Vinelab\NeoEloquent;
 
-use Vinelab\NeoEloquent\Support\ServiceProvider;
-use Illuminate\Database\Migrations\Migrator;
 use Vinelab\NeoEloquent\Migrations\MigrationModel;
 use Vinelab\NeoEloquent\Migrations\MigrationCreator;
 use Vinelab\NeoEloquent\Console\Migrations\MigrateCommand;
@@ -12,6 +10,8 @@ use Vinelab\NeoEloquent\Console\Migrations\MigrateResetCommand;
 use Vinelab\NeoEloquent\Migrations\DatabaseMigrationRepository;
 use Vinelab\NeoEloquent\Console\Migrations\MigrateRefreshCommand;
 use Vinelab\NeoEloquent\Console\Migrations\MigrateRollbackCommand;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Support\ServiceProvider;
 
 class MigrationServiceProvider extends ServiceProvider
 {

--- a/src/NeoEloquentServiceProvider.php
+++ b/src/NeoEloquentServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Vinelab\NeoEloquent;
 
 use Vinelab\NeoEloquent\Eloquent\Model;
-use Vinelab\NeoEloquent\Support\ServiceProvider;
 use Vinelab\NeoEloquent\Schema\Grammars\CypherGrammar;
+use Illuminate\Support\ServiceProvider;
 
 class NeoEloquentServiceProvider extends ServiceProvider
 {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -5,11 +5,8 @@ namespace Vinelab\NeoEloquent\Query;
 use Closure;
 use DateTime;
 use Carbon\Carbon;
-use Vinelab\NeoEloquent\Support\Arr;
-use Vinelab\NeoEloquent\Support\Str;
 use BadMethodCallException;
 use InvalidArgumentException;
-use Vinelab\NeoEloquent\Connection;
 use Vinelab\NeoEloquent\ConnectionInterface;
 use Vinelab\NeoEloquent\Pagination\Paginator;
 use Neoxygen\NeoClient\Formatter\Result;
@@ -17,7 +14,8 @@ use Vinelab\NeoEloquent\Contracts\Support\Arrayable;
 use Vinelab\NeoEloquent\Eloquent\Collection;
 use Vinelab\NeoEloquent\Pagination\LengthAwarePaginator;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
-use Vinelab\NeoEloquent\Query\Processors\Processor;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class Builder
 {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -8,14 +8,14 @@ use Carbon\Carbon;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Vinelab\NeoEloquent\ConnectionInterface;
-use Vinelab\NeoEloquent\Pagination\Paginator;
 use Neoxygen\NeoClient\Formatter\Result;
 use Vinelab\NeoEloquent\Contracts\Support\Arrayable;
 use Vinelab\NeoEloquent\Eloquent\Collection;
-use Vinelab\NeoEloquent\Pagination\LengthAwarePaginator;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 
 class Builder
 {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -9,9 +9,10 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use Vinelab\NeoEloquent\ConnectionInterface;
 use Neoxygen\NeoClient\Formatter\Result;
-use Vinelab\NeoEloquent\Contracts\Support\Arrayable;
 use Vinelab\NeoEloquent\Eloquent\Collection;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
+
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -1391,7 +1392,7 @@ class Builder
      * @param string   $pageName
      * @param int|null $page
      *
-     * @return \Vinelab\NeoEloquent\Contracts\Pagination\LengthAwarePaginator
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
     {
@@ -1416,7 +1417,7 @@ class Builder
      * @param array  $columns
      * @param string $pageName
      *
-     * @return \Vinelab\NeoEloquent\Contracts\Pagination\Paginator
+     * @return \Illuminate\Contracts\Pagination\Paginator
      */
     public function simplePaginate($perPage = 15, $columns = ['*'], $pageName = 'page')
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -5,7 +5,7 @@ namespace Vinelab\NeoEloquent\Schema;
 use Closure;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Grammars\Grammar as IlluminateSchemaGrammar;
-use Vinelab\NeoEloquent\Support\Fluent;
+use Illuminate\Support\Fluent;
 
 class Blueprint
 {
@@ -80,7 +80,7 @@ class Blueprint
     /**
      * Indicate that the label should be dropped.
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function drop()
     {
@@ -90,7 +90,7 @@ class Blueprint
     /**
      * Indicate that the label should be dropped if it exists.
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function dropIfExists()
     {
@@ -102,7 +102,7 @@ class Blueprint
      *
      * @param string $to
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function renameLabel($to)
     {
@@ -114,7 +114,7 @@ class Blueprint
      *
      * @param string|array $properties
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function dropUnique($properties)
     {
@@ -130,7 +130,7 @@ class Blueprint
      *
      * @param string|array $properties
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function dropIndex($properties)
     {
@@ -146,7 +146,7 @@ class Blueprint
      *
      * @param string|array $properties
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function unique($properties)
     {
@@ -162,7 +162,7 @@ class Blueprint
      *
      * @param string|array $properties
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     public function index($properties)
     {
@@ -179,7 +179,7 @@ class Blueprint
      * @param string $name
      * @param array  $parameters
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     protected function addCommand($name, array $parameters = [])
     {
@@ -194,7 +194,7 @@ class Blueprint
      * @param string $name
      * @param array  $parameters
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     protected function createCommand($name, array $parameters = [])
     {
@@ -212,7 +212,7 @@ class Blueprint
      * @param string|array $property
      * @param string       $index
      *
-     * @return \Vinelab\NeoEloquent\Support\Fluent
+     * @return \Illuminate\Support\Fluent
      */
     protected function indexCommand($type, $property)
     {

--- a/src/Schema/Grammars/CypherGrammar.php
+++ b/src/Schema/Grammars/CypherGrammar.php
@@ -2,8 +2,8 @@
 
 namespace Vinelab\NeoEloquent\Schema\Grammars;
 
-use Vinelab\NeoEloquent\Support\Fluent;
 use Vinelab\NeoEloquent\Schema\Blueprint;
+use Illuminate\Support\Fluent;
 
 class CypherGrammar extends Grammar
 {

--- a/tests/Vinelab/NeoEloquent/ConnectionFactoryTest.php
+++ b/tests/Vinelab/NeoEloquent/ConnectionFactoryTest.php
@@ -4,8 +4,8 @@ namespace Vinelab\NeoEloquent\Tests;
 
 use Neoxygen\NeoClient\Client;
 use Vinelab\NeoEloquent\Connection;
-use Vinelab\NeoEloquent\Container\Container;
 use Vinelab\NeoEloquent\Connectors\ConnectionFactory;
+use Illuminate\Container\Container;
 
 class ConnectionFactoryTest extends TestCase
 {

--- a/tests/Vinelab/NeoEloquent/ConnectionTest.php
+++ b/tests/Vinelab/NeoEloquent/ConnectionTest.php
@@ -112,7 +112,7 @@ class ConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection();
         $connection->logQuery('foo', array(), time());
-        $connection->setEventDispatcher($events = M::mock('Vinelab\NeoEloquent\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = M::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with('illuminate.query', array('foo', array(), null, null));
         $connection->logQuery('foo', array(), null);
     }
@@ -429,7 +429,7 @@ class ConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection(array('getName'));
         $connection->expects($this->once())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = M::mock('Vinelab\NeoEloquent\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = M::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with('connection.name.beganTransaction', $connection);
         $connection->beginTransaction();
     }
@@ -438,7 +438,7 @@ class ConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection(array('getName'));
         $connection->expects($this->once())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = M::mock('Vinelab\NeoEloquent\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = M::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with('connection.name.committed', $connection);
         $connection->commit();
     }
@@ -447,7 +447,7 @@ class ConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection(array('getName'));
         $connection->expects($this->once())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = M::mock('Vinelab\NeoEloquent\Contracts\Events\Dispatcher'));
+        $connection->setEventDispatcher($events = M::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('fire')->once()->with('connection.name.rollingBack', $connection);
         $connection->rollback();
     }

--- a/tests/Vinelab/NeoEloquent/Eloquent/BuilderTest.php
+++ b/tests/Vinelab/NeoEloquent/Eloquent/BuilderTest.php
@@ -379,7 +379,7 @@ class EloquentBuilderTest extends TestCase
         $this->model->shouldReceive('getConnectionName')->once()->andReturn('default');
 
         $result = M::mock('Neoxygen\NeoClient\Formatter\Result');
-        $collection = new \Vinelab\NeoEloquent\Support\Collection(array($result));
+        $collection = new \Illuminate\Support\Collection(array($result));
         $this->model->shouldReceive('newCollection')->once()->andReturn($collection);
 
         $this->builder->setModel($this->model);
@@ -422,7 +422,7 @@ class EloquentBuilderTest extends TestCase
         $attributes = array_merge($result, array('id' => $id));
 
         // the Collection that represents the returned result by Eloquent holding the User as an item
-        $collection = new \Vinelab\NeoEloquent\Support\Collection(array($user));
+        $collection = new \Illuminate\Support\Collection(array($user));
 
         $this->model->shouldReceive('newCollection')->once()->andReturn($collection)
                     ->shouldReceive('getKeyName')->times(3)->andReturn('id')


### PR DESCRIPTION
I don't understand why there are forks of Illuminate\Support, Pagination, Contracts, Container and Events without any changes. All forks are behind master (Illuminate\Support over 400 Commits) and may contains bugs and security problems.

With this PR I changed all use-statements to the original Illuminate classes.