### PR TITLE
Allow Multiple Connections for Laravel 5.4

### DIFF
--- a/src/Vinelab/NeoEloquent/Eloquent/Model.php
+++ b/src/Vinelab/NeoEloquent/Eloquent/Model.php
@@ -25,6 +25,13 @@ abstract class Model extends IlluminateModel {
     protected $label = null;
 
     /**
+     * Connection Name
+     *
+     * @var string
+     */
+    protected $connectionName = null;
+
+    /**
      * Set the node label for this model
      *
      * @param  string|array  $label
@@ -66,6 +73,11 @@ abstract class Model extends IlluminateModel {
      */
     protected function newBaseQueryBuilder()
     {
+        if(!empty($this->connectionName))
+        {
+            $this->setConnection($this->connectionName);
+        }
+
         $conn = $this->getConnection();
 
         $grammar = $conn->getQueryGrammar();


### PR DESCRIPTION
This will allow a custom definition of the connection to use in each single model.

The following line must be added to your model to overwrite the default connection:
> protected $connectionName = "YOUR_CONNECTION_NAME";