### PR TITLE
Updated migration commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/database": "5.5.*",
         "illuminate/pagination": "5.5.*",
         "illuminate/events": "5.5.*",
+        "illuminate/console": "5.5.*",
         "heydavid713/neo4jphp": "0.1.*",
         "nesbot/carbon": "~1.0"
     },

--- a/src/Console/Migrations/BaseCommand.php
+++ b/src/Console/Migrations/BaseCommand.php
@@ -1,9 +1,12 @@
-<?php namespace Vinelab\NeoEloquent\Console\Migrations;
+<?php
+
+
+namespace Vinelab\NeoEloquent\Console\Migrations;
 
 use Illuminate\Console\Command;
 
-class BaseCommand extends Command {
-
+class BaseCommand extends Command
+{
     /**
      * Directory for Neo4j labels migrations.
      *
@@ -14,43 +17,29 @@ class BaseCommand extends Command {
     /**
      * Get the path to the migration directory.
      *
+     * @return array
+     */
+    protected function getMigrationPaths()
+    {
+        // Here, we will check to see if a path option has been defined. If it has we will
+        // use the path relative to the root of the installation folder so our database
+        // migrations may be run for any customized path from within the application.
+        if ($this->input->hasOption('path') && $this->option('path')) {
+            return collect($this->option('path'))->map(function ($path) {
+                return $this->laravel->basePath().'/'.$path;
+            })->all();
+        }
+
+        return [$this->getMigrationPath()];
+    }
+
+    /**
+     * Get the path to the migration directory.
+     *
      * @return string
      */
     protected function getMigrationPath()
     {
-        $path = $this->input->getOption('path');
-
-        // First, we will check to see if a path option has been defined. If it has
-        // we will use the path relative to the root of this installation folder
-        // so that migrations may be run for any path within the applications.
-        if ( ! is_null($path))
-        {
-            return $this->laravel['path.base'].'/'.$path;
-        }
-
-        $package = $this->input->getOption('package');
-
-        // If the package is in the list of migration paths we received we will put
-        // the migrations in that path. Otherwise, we will assume the package is
-        // is in the package directories and will place them in that location.
-        if ( ! is_null($package))
-        {
-            return $this->packagePath.'/'.$package.'/src/' . self::LABELS_DIRECTORY;
-        }
-
-        $bench = $this->input->getOption('bench');
-
-        // Finally we will check for the workbench option, which is a shortcut into
-        // specifying the full path for a "workbench" project. Workbenches allow
-        // developers to develop packages along side a "standard" app install.
-        if ( ! is_null($bench))
-        {
-            $path = "/workbench/{$bench}/src/" . self::LABELS_DIRECTORY;
-
-            return $this->laravel['path.base'].$path;
-        }
-
-        return $this->laravel['path.database'].'/'.self::LABELS_DIRECTORY;
+        return $this->laravel->databasePath().DIRECTORY_SEPARATOR.self::LABELS_DIRECTORY;
     }
-
 }

--- a/src/Console/Migrations/MigrateCommand.php
+++ b/src/Console/Migrations/MigrateCommand.php
@@ -1,110 +1,83 @@
-<?php namespace Vinelab\NeoEloquent\Console\Migrations;
+<?php
+
+
+namespace Vinelab\NeoEloquent\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
-use Symfony\Component\Console\Input\InputOption;
 
-class MigrateCommand extends BaseCommand {
-
+class MigrateCommand extends BaseCommand
+{
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * The name and signature of the console command.
+     *
+     * @var string
      */
-    protected $name = 'neo4j:migrate';
+    protected $signature = 'neo4j:migrate {--database= : The database connection to use.}
+                {--force : Force the operation to run when in production.}
+                {--path= : The path of migrations files to be executed.}
+                {--pretend : Dump the SQL queries that would be run.}
+                {--seed : Indicates if the seed task should be re-run.}
+                {--step : Force the migrations to be run so they can be rolled back individually.}';
 
     /**
-     * {@inheritDoc}
+     * The console command description.
+     *
+     * @var string
      */
     protected $description = 'Run the database migrations';
 
     /**
      * The migrator instance.
      *
-     * @var \Vinelab\NeoEloquent\Migrations\Migrator
+     * @var \Illuminate\Database\Migrations\Migrator
      */
     protected $migrator;
 
     /**
-     * The path to the packages directory (vendor).
-     */
-    protected $packagePath;
-
-    /**
-     * @param  \Vinelab\NeoEloquent\Migrations\Migrator  $migrator
-     * @param  string  $packagePath
+     * @param  \Illuminate\Database\Migrations\Migrator $migrator
      * @return void
      */
-    public function __construct(Migrator $migrator, $packagePath)
+    public function __construct(Migrator $migrator)
     {
         parent::__construct();
 
         $this->migrator = $migrator;
-        $this->packagePath = $packagePath;
     }
 
     /**
-     * {@inheritDoc}
+     * Execute the console command.
+     *
+     * @return void
      */
-    public function fire()
+    public function handle()
     {
-        if ( ! $this->confirmToProceed())
-        {
+        if (! $this->confirmToProceed()) {
             return;
         }
 
-        // The pretend option can be used for "simulating" the migration and grabbing
-        // the SQL queries that would fire if the migration were to be run against
-        // a database for real, which is helpful for double checking migrations.
-        $pretend = $this->input->getOption('pretend');
+        $this->migrator->setConnection($this->option('database'));
 
-        $path = $this->getMigrationPath();
-
-        $this->migrator->setConnection($this->input->getOption('database'));
-        $this->migrator->run($path, [
-            'pretend' => $pretend,
-            'step' => $this->input->getOption('step'),
+        // Next, we will check to see if a path option has been defined. If it has
+        // we will use the path relative to the root of this installation folder
+        // so that migrations may be run for any path within the applications.
+        $this->migrator->run($this->getMigrationPaths(), [
+            'pretend' => $this->option('pretend'),
+            'step' => $this->option('step'),
         ]);
-
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
         // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note)
-        {
+        foreach ($this->migrator->getNotes() as $note) {
             $this->output->writeln($note);
         }
-
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.
-        if ($this->input->getOption('seed'))
-        {
+        if ($this->option('seed')) {
             $this->call('db:seed', ['--force' => true]);
         }
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getOptions()
-    {
-        return array(
-            array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
-
-            array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-
-            array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
-
-            array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
-
-            array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
-
-            array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-
-            array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
-
-            array('step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually.'),
-        );
-    }
-
 }

--- a/src/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Console/Migrations/MigrateMakeCommand.php
@@ -1,35 +1,34 @@
 <?php
+
+
 namespace Vinelab\NeoEloquent\Console\Migrations;
 
 use Illuminate\Support\Composer;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Vinelab\NeoEloquent\Migrations\MigrationCreator;
 
 class MigrateMakeCommand extends BaseCommand
 {
-
     /**
-     * {@inheritDoc}
+     * The console command signature.
+     *
+     * @var string
      */
-    protected $name = 'neo4j:make:migration';
+    protected $signature = 'neo4j:make:migration {name : The name of the migration.}
+        {--create= : The table to be created.}
+        {--label= : The label to migrate.}
+        {--path= : The location where the migration file should be created.}';
 
     /**
-     * {@inheritDoc}
+     * The console command description.
+     *
+     * @var string
      */
     protected $description = 'Create a new migration file';
 
     /**
-     * @var \Vinelab\NeoEloquent\Migrations\MigrationCreator
+     * @var \Illuminate\Database\Migrations\MigrationCreator
      */
     protected $creator;
-
-    /**
-     * The path to the packages directory (vendor).
-     *
-     * @var string
-     */
-    protected $packagePath;
 
     /**
      * @var \Illuminate\Support\Composer
@@ -38,41 +37,55 @@ class MigrateMakeCommand extends BaseCommand
 
     /**
      * @param  \Vinelab\NeoEloquent\Migrations\MigrationCreator  $creator
-     * @param  string  $packagePath
+     * @param  \Illuminate\Support\Composer  $composer
      * @return void
      */
-    public function __construct(MigrationCreator $creator, Composer $composer, $packagePath)
+    public function __construct(MigrationCreator $creator, Composer $composer)
     {
         parent::__construct();
 
         $this->creator = $creator;
-        $this->packagePath = $packagePath;
         $this->composer = $composer;
     }
 
     /**
-     * {@inheritDoc}
+     * Execute the console command.
+     *
+     * @return void
      */
-    public function fire()
+    public function handle()
     {
-        // It's possible for the developer to specify the tables to modify in this
+        // It's possible for the developer to specify the labels to modify in this
         // schema operation. The developer may also specify if this label needs
         // to be freshly created so we can create the appropriate migrations.
-        $name = $this->input->getArgument('name');
+        $name = trim($this->input->getArgument('name'));
 
         $label = $this->input->getOption('label');
 
-        $modify = $this->input->getOption('create');
+        $create = $this->input->getOption('create') ?: false;
 
-        if ( ! $label && is_string($modify))
-        {
-            $label = $modify;
+        // If no label was given as an option but a create option is given then we
+        // will use the "create" option as the label name. This allows the devs
+        // to pass a label name into this option as a short-cut for creating.
+        if (! $label && is_string($create)) {
+            $label = $create;
+            $create = true;
+        }
+
+        // Next, we will attempt to guess the label name if this the migration has
+        // "create" in the name. This will allow us to provide a convenient way
+        // of creating migrations that create new labels for the application.
+        if (! $label) {
+            if (preg_match('/^create_(\w+)_label$/', $name, $matches)) {
+                $label = $matches[1];
+                $create = true;
+            }
         }
 
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $label);
+        $this->writeMigration($name, $label, $create);
 
         $this->composer->dumpAutoloads();
     }
@@ -85,41 +98,25 @@ class MigrateMakeCommand extends BaseCommand
      * @param  bool    $create
      * @return string
      */
-    protected function writeMigration($name, $label)
+    protected function writeMigration($name, $label, $create)
     {
-        $path = $this->getMigrationPath();
-
-        $file = pathinfo($this->creator->create($name, $path, $label), PATHINFO_FILENAME);
+        $file = pathinfo($this->creator->create(
+            $name, $this->getMigrationPath(), $label, $create
+        ), PATHINFO_FILENAME);
 
         $this->line("<info>Created Migration:</info> $file");
     }
 
     /**
-     * {@inheritDoc}
+     * Get migration path (either specified by '--path' option or default location).
+     *
+     * @return string
      */
-    protected function getArguments()
+    protected function getMigrationPath()
     {
-        return array(
-            array('name', InputArgument::REQUIRED, 'The name of the migration'),
-        );
+        if (! is_null($targetPath = $this->input->getOption('path'))) {
+            return $this->laravel->basePath().'/'.$targetPath;
+        }
+        return parent::getMigrationPath();
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function getOptions()
-    {
-        return array(
-            array('bench', null, InputOption::VALUE_OPTIONAL, 'The workbench the migration belongs to.', null),
-
-            array('create', null, InputOption::VALUE_OPTIONAL, 'The label schema to be created.'),
-
-            array('package', null, InputOption::VALUE_OPTIONAL, 'The package the migration belongs to.', null),
-
-            array('path', null, InputOption::VALUE_OPTIONAL, 'Where to store the migration.', null),
-
-            array('label', null, InputOption::VALUE_OPTIONAL, 'The label to migrate.'),
-        );
-    }
-
 }

--- a/src/Console/Migrations/MigrateRefreshCommand.php
+++ b/src/Console/Migrations/MigrateRefreshCommand.php
@@ -1,49 +1,108 @@
-<?php namespace Vinelab\NeoEloquent\Console\Migrations;
+<?php
 
-use Illuminate\Console\Command;
+
+namespace Vinelab\NeoEloquent\Console\Migrations;
+
 use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
 
-class MigrateRefreshCommand extends Command {
-
+class MigrateRefreshCommand extends BaseCommand
+{
     use ConfirmableTrait;
 
     /**
-     * {@inheritDoc}
+     * The console command name.
+     *
+     * @var string
      */
     protected $name = 'neo4j:migrate:refresh';
 
     /**
-     * {@inheritDoc}
+     * The console command description.
+     *
+     * @var string
      */
     protected $description = 'Reset and re-run all migrations';
 
     /**
-     * {@inheritDoc}
+     * Execute the console command.
+     *
+     * @return void
      */
-    public function fire()
+    public function handle()
     {
-        if ( ! $this->confirmToProceed()) return;
+        if (! $this->confirmToProceed()) {
+            return;
+        }
 
+        // Next we'll gather some of the options so that we can have the right options
+        // to pass to the commands. This includes options such as which database to
+        // use and the path to use for the migration. Then we'll run the command.
         $database = $this->input->getOption('database');
+
+        $path = $this->input->getOption('path');
 
         $force = $this->input->getOption('force');
 
-        $this->call('migrate:reset', array(
-            '--database' => $database, '--force' => $force
-        ));
+        // If the "step" option is specified it means we only want to rollback a small
+        // number of migrations before migrating again. For example, the user might
+        // only rollback and remigrate the latest four migrations instead of all.
+        $step = $this->input->getOption('step') ?: 0;
+
+        if ($step > 0) {
+            $this->runRollback($database, $path, $step, $force);
+        } else {
+            $this->runReset($database, $path, $force);
+        }
 
         // The refresh command is essentially just a brief aggregate of a few other of
         // the migration commands and just provides a convenient wrapper to execute
         // them in succession. We'll also see if we need to re-seed the database.
-        $this->call('migrate', array(
-            '--database' => $database, '--force' => $force
-        ));
+        $this->call('neo4j:migrate', [
+            '--database' => $database,
+            '--path' => $path,
+            '--force' => $force,
+        ]);
 
-        if ($this->needsSeeding())
-        {
+        if ($this->needsSeeding()) {
             $this->runSeeder($database);
         }
+    }
+
+    /**
+     * Run the rollback command.
+     *
+     * @param  string  $database
+     * @param  string  $path
+     * @param  bool  $step
+     * @param  bool  $force
+     * @return void
+     */
+    protected function runRollback($database, $path, $step, $force)
+    {
+        $this->call('neo4j:migrate:rollback', [
+            '--database' => $database,
+            '--path' => $path,
+            '--step' => $step,
+            '--force' => $force,
+        ]);
+    }
+
+    /**
+     * Run the reset command.
+     *
+     * @param  string  $database
+     * @param  string  $path
+     * @param  bool  $force
+     * @return void
+     */
+    protected function runReset($database, $path, $force)
+    {
+        $this->call('neo4j:migrate:reset', [
+            '--database' => $database,
+            '--path' => $path,
+            '--force' => $force,
+        ]);
     }
 
     /**
@@ -64,25 +123,32 @@ class MigrateRefreshCommand extends Command {
      */
     protected function runSeeder($database)
     {
-        $class = $this->option('seeder') ?: 'DatabaseSeeder';
-
-        $this->call('db:seed', array('--database' => $database, '--class' => $class));
+        $this->call('db:seed', [
+            '--database' => $database,
+            '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
+            '--force' => $this->option('force'),
+        ]);
     }
 
     /**
-     * {@inheritDoc}
+     * Get the console command options.
+     *
+     * @return array
      */
     protected function getOptions()
     {
-        return array(
-            array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-            array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-            array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
-            array('seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'),
-        );
+            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+
+            ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+
+            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted & re-run.'],
+        ];
     }
-
 }

--- a/src/Migrations/DatabaseMigrationRepository.php
+++ b/src/Migrations/DatabaseMigrationRepository.php
@@ -194,8 +194,28 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
      */
     public function getMigrations($steps)
     {
-        $query = $this->label()->where('batch', '>=', '1');
-        return $query->orderBy('migration', 'desc')->take($steps)->get()->all();
+        $query = $this->label()->where('batch', '>=', 1);
+        $results = [];
+
+        $rows = $query->orderBy('batch', 'desc')
+            ->orderBy('migration', 'desc')
+            ->take($steps)->get();
+
+        $columns = $rows->getColumns();
+
+        foreach ($rows as $row) {
+            $attributes = [];
+
+            foreach ($columns as $column) {
+                foreach ($row[$column]->getProperties() as $key => $value) {
+                    $attributes[$key] = $value;
+                }
+            }
+
+            $results[] = $attributes;
+        }
+
+        return $results;
     }
 
 }

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -30,7 +30,7 @@ class MigrationCreator extends IlluminateMigrationCreator {
     /**
      * {@inheritDoc}
      */
-    public function getStubPath()
+    public function stubPath()
     {
         return __DIR__ . '/stubs';
     }

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -14,14 +14,14 @@ class MigrationCreator extends IlluminateMigrationCreator {
      */
     protected function populateStub($name, $stub, $label)
     {
-        $stub = str_replace('{{class}}', studly_case($name), $stub);
+        $stub = str_replace('DummyClass', studly_case($name), $stub);
 
         // Here we will replace the label place-holders with the label specified by
         // the developer, which is useful for quickly creating a labels creation
         // or update migration from the console instead of typing it manually.
         if ( ! is_null($label))
         {
-            $stub = str_replace('{{label}}', $label, $stub);
+            $stub = str_replace('DummyLabel', $label, $stub);
         }
 
         return $stub;

--- a/src/Migrations/stubs/blank.stub
+++ b/src/Migrations/stubs/blank.stub
@@ -3,7 +3,7 @@
 use Vinelab\NeoEloquent\Schema\Blueprint;
 use Vinelab\NeoEloquent\Migrations\Migration;
 
-class {{class}} extends Migration {
+class DummyClass extends Migration {
 
     /**
      * Run the migrations.

--- a/src/Migrations/stubs/create.stub
+++ b/src/Migrations/stubs/create.stub
@@ -3,7 +3,7 @@
 use Vinelab\NeoEloquent\Schema\Blueprint;
 use Vinelab\NeoEloquent\Migrations\Migration;
 
-class {{class}} extends Migration {
+class DummyClass extends Migration {
 
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class {{class}} extends Migration {
      */
     public function up()
     {
-        Neo4jSchema::label('{{label}}', function(Blueprint $label)
+        Neo4jSchema::label('DummyLabel', function(Blueprint $label)
         {
             //
         });
@@ -25,10 +25,7 @@ class {{class}} extends Migration {
      */
     public function down()
     {
-        Neo4jSchema::label('{{label}}', function(Blueprint $label)
-        {
-            //
-        });
+        Neo4jSchema::dropIfExists('DummyLabel');
     }
 
 }

--- a/src/Migrations/stubs/update.stub
+++ b/src/Migrations/stubs/update.stub
@@ -3,7 +3,7 @@
 use Vinelab\NeoEloquent\Schema\Blueprint;
 use Vinelab\NeoEloquent\Migrations\Migration;
 
-class {{class}} extends Migration {
+class DummyClass extends Migration {
 
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class {{class}} extends Migration {
      */
     public function up()
     {
-        Neo4jSchema::label('{{label}}', function(Blueprint $label)
+        Neo4jSchema::label('DummyLabel', function(Blueprint $label)
         {
             //
         });
@@ -25,7 +25,7 @@ class {{class}} extends Migration {
      */
     public function down()
     {
-        Neo4jSchema::label('{{label}}', function(Blueprint $label)
+        Neo4jSchema::label('DummyLabel', function(Blueprint $label)
         {
             //
         });

--- a/src/Query/Grammars/Grammar.php
+++ b/src/Query/Grammars/Grammar.php
@@ -327,7 +327,7 @@ class Grammar extends IlluminateGrammar {
      */
     public function getUniqueLabel($label)
     {
-        return $label.$this->labelPostfix.uniqid();
+        return $label.$this->labelPostfix.bin2hex(random_bytes(8));
     }
 
     /**

--- a/tests/functional/QueryingRelationsTest.php
+++ b/tests/functional/QueryingRelationsTest.php
@@ -627,7 +627,7 @@ class QueryingRelationsTest extends TestCase {
     public function testSavingRelationWithDateTimeAndCarbonInstances()
     {
         $user = User::create(['name' => 'Andrew Hale']);
-        $yesterday = Carbon::now();
+        $yesterday = Carbon::now()->subDay();
         $brother = new User(['name' => 'Simon Hale', 'dob' => $yesterday]);
 
         $dt = new DateTime();
@@ -638,7 +638,7 @@ class QueryingRelationsTest extends TestCase {
 
         $andrew = User::where('name', 'Andrew Hale')->first();
 
-        $colleagues = $andrew->colleagues()->get();
+        $colleagues = $andrew->colleagues()->orderBy('dob', 'DESC')->get();
         $this->assertEquals($dt->format(User::getDateFormat()), $colleagues[0]->dob);
         $this->assertEquals($yesterday->format(User::getDateFormat()), $colleagues[1]->dob);
     }


### PR DESCRIPTION
Update for Laravel 5.5
- handle instead of fire for all commands
- consistency with Laravel migration commands
- stubs are used now with neo4j:make:migration command
- it is possible to use steps for neo4j:migrate:rollback and neo4j:migrate:reset
- neo4j:migrate:reset and neo4j:migrate:refresh are working