### PR TITLE
add missing `getForeignKeyName` method

### DIFF
--- a/src/Eloquent/Relations/BelongsTo.php
+++ b/src/Eloquent/Relations/BelongsTo.php
@@ -107,5 +107,27 @@ class BelongsTo extends OneRelation {
         $unique = true;
         return new EdgeIn($this->query, $this->parent, $model, $this->foreignKey, $attributes, $unique);
     }
+    
+    /**
+     * Get the plain foreign key.
+     *
+     * @return string
+     */
+    public function getForeignKeyName()
+    {
+        $segments = explode('.', $this->getQualifiedForeignKeyName());
+
+        return end($segments);
+    }
+
+    /**
+     * Get the foreign key for the relationship.
+     *
+     * @return string
+     */
+    public function getQualifiedForeignKeyName()
+    {
+        return $this->foreignKey;
+    }
 
 }


### PR DESCRIPTION
This fixes the issue with the `belongsTo` method, as described in  https://github.com/Vinelab/NeoEloquent/issues/281.

Code is copy-pasted from the `\Illuminate\Database\Eloquent\Relations\HasOneOrMany` class. No good style, I know, but it was the least invasive way to solve the immediate problem.

I tested it locally (works for all of my use cases) and Travis is still happy, too (https://travis-ci.org/dgerike/NeoEloquent/).