### PR TITLE
WhereRaw should work even when using scopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.6.*",
-        "illuminate/database": "5.6.*",
-        "illuminate/pagination": "5.6.*",
-        "illuminate/events": "5.6.*",
-        "illuminate/console": "5.6.*",
+        "illuminate/support": "5.7.*",
+        "illuminate/database": "5.7.*",
+        "illuminate/pagination": "5.7.*",
+        "illuminate/events": "5.7.*",
+        "illuminate/console": "5.7.*",
         "heydavid713/neo4jphp": "0.1.*",
         "nesbot/carbon": "~1.0"
     },

--- a/src/Console/Migrations/MigrateCommand.php
+++ b/src/Console/Migrations/MigrateCommand.php
@@ -70,7 +70,7 @@ class MigrateCommand extends BaseCommand
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
         // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
+        foreach ($this->migrator->setOutput($this->output) as $note) {
             $this->output->writeln($note);
         }
         // Finally, if the "seed" option has been given, we will re-run the database

--- a/src/Eloquent/Relations/BelongsTo.php
+++ b/src/Eloquent/Relations/BelongsTo.php
@@ -109,6 +109,16 @@ class BelongsTo extends OneRelation {
     }
     
     /**
+     * Get the results of the relationship.
+     *
+     * @return mixed
+     */
+    public function getResults()
+    {
+        return $this->query->first() ?: $this->getDefaultFor($this->parent);
+    }
+
+    /**
      * Get the plain foreign key.
      *
      * @return string

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -388,7 +388,7 @@ class Builder extends IlluminateQueryBuilder {
     {
         if (is_array($this->wheres))
             return count(array_filter($this->wheres, function($where) use($column) {
-                return $where['type'] !== 'raw' && $where['column'] == $column;
+                return isset($where['column']) && $where['column'] == $column;
             }));
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -388,7 +388,7 @@ class Builder extends IlluminateQueryBuilder {
     {
         if (is_array($this->wheres))
             return count(array_filter($this->wheres, function($where) use($column) {
-                return $where['column'] == $column;
+                return $where['type'] !== 'raw' && $where['column'] == $column;
             }));
     }
 
@@ -792,7 +792,7 @@ class Builder extends IlluminateQueryBuilder {
      */
     public function addBinding($value, $type = 'where')
     {
-        if (is_array($value))
+        if (is_array($value) && count($value) > 0)
         {
             $key = array_keys($value)[0];
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -42,6 +42,13 @@ class Builder extends IlluminateQueryBuilder {
     public $with = array();
 
     /**
+     * The WHERE statements to be executed after the WITH statement
+     * 
+     * @var array
+     */
+    public $withWheres = array();
+    
+    /**
      * The current query value bindings.
      *
      * @var array
@@ -484,7 +491,7 @@ class Builder extends IlluminateQueryBuilder {
     {
         $type = 'Carried';
 
-        $this->wheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
+        $this->withWheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
         return $this;
     }

--- a/src/Query/Grammars/CypherGrammar.php
+++ b/src/Query/Grammars/CypherGrammar.php
@@ -10,6 +10,7 @@ class CypherGrammar extends Grammar {
         'from',
         'wheres',
         'with',
+        'withWheres',
         'unions',
         'columns',
         'orders',
@@ -295,6 +296,38 @@ class CypherGrammar extends Grammar {
         // for actually creating the where clauses Cypher. This helps keep the code nice
         // and maintainable since each clause has a very small method that it uses.
         foreach ($query->wheres as $where)
+        {
+            $method = "WHERE{$where['type']}";
+
+            $cypher[] = $where['boolean'].' '.$this->$method($query, $where);
+        }
+
+        // If we actually have some where clauses, we will strip off the first boolean
+        // operator, which is added by the query builders for convenience so we can
+        // avoid checking for the first clauses in each of the compilers methods.
+        if (count($cypher) > 0)
+        {
+            $cypher = implode(' ', $cypher);
+
+            return 'WHERE '.preg_replace('/and |or /', '', $cypher, 1);
+        }
+
+        return '';
+    }
+
+    /**
+     * Compile whereas after the WITH statement
+     */
+    protected function compileWithWheres(Builder $query)
+    {
+        $cypher = array();
+
+        if (is_null($query->withWheres)) return '';
+
+        // Each type of where clauses has its own compiler function which is responsible
+        // for actually creating the where clauses Cypher. This helps keep the code nice
+        // and maintainable since each clause has a very small method that it uses.
+        foreach ($query->withWheres as $where)
         {
             $method = "WHERE{$where['type']}";
 

--- a/src/Query/Grammars/CypherGrammar.php
+++ b/src/Query/Grammars/CypherGrammar.php
@@ -404,7 +404,7 @@ class CypherGrammar extends Grammar {
     public function compileOrders(Builder $query, $orders)
     {
         return 'ORDER BY '. implode(', ', array_map(function($order){
-                if (isset($order['type']) && $order['type'] == 'raw') {
+                if (isset($order['type']) && $order['type'] == 'Raw') {
                     return $order['sql'];
                 }
                 return $this->wrap($order['column']).' '.mb_strtoupper($order['direction']);

--- a/src/Query/Grammars/CypherGrammar.php
+++ b/src/Query/Grammars/CypherGrammar.php
@@ -8,8 +8,8 @@ class CypherGrammar extends Grammar {
     protected $selectComponents = array(
         'matches',
         'from',
-        'with',
         'wheres',
+        'with',
         'unions',
         'columns',
         'orders',

--- a/src/Query/Grammars/CypherGrammar.php
+++ b/src/Query/Grammars/CypherGrammar.php
@@ -404,6 +404,9 @@ class CypherGrammar extends Grammar {
     public function compileOrders(Builder $query, $orders)
     {
         return 'ORDER BY '. implode(', ', array_map(function($order){
+                if (isset($order['type']) && $order['type'] == 'raw') {
+                    return $order['sql'];
+                }
                 return $this->wrap($order['column']).' '.mb_strtoupper($order['direction']);
         }, $orders));
     }

--- a/tests/Vinelab/NeoEloquent/Eloquent/BuilderTest.php
+++ b/tests/Vinelab/NeoEloquent/Eloquent/BuilderTest.php
@@ -218,7 +218,7 @@ class EloquentBuilderTest extends TestCase {
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->orders')->once()->andReturn($relation = m::mock('stdClass'));
         $relationQuery = m::mock('stdClass');
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
         $relationQuery->shouldReceive('with')->once()->with(array('lines' => null, 'lines.details' => null));
@@ -231,8 +231,8 @@ class EloquentBuilderTest extends TestCase {
     {
         $builder = $this->getBuilder();
         $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
-        $builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->orders')->once()->andReturn($relation = m::mock('stdClass'));
+        $builder->getModel()->shouldReceive('newInstance->ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
 
         $relationQuery = m::mock('stdClass');
         $relation->shouldReceive('getQuery')->andReturn($relationQuery);
@@ -684,7 +684,6 @@ class EloquentBuilderTest extends TestCase {
         $query = m::mock('Vinelab\NeoEloquent\Query\Builder');
         $query->shouldReceive('from')->with('foo_table');
         $query->shouldReceive('modelAsNode')->andReturn('n');
-        echo implode(", ", get_class_methods($query)), "\n";
         return $query;
     }
 

--- a/tests/functional/ModelEventsTest.php
+++ b/tests/functional/ModelEventsTest.php
@@ -10,7 +10,6 @@ class ModelEventsTest extends TestCase {
     public function tearDown()
     {
         M::close();
-
         parent::tearDown();
     }
 
@@ -136,7 +135,7 @@ class User extends Model {
         $dispatcher->shouldReceive('until')->andReturnUsing(function($event, $model){
             if (isset(static::$listenerStub[$event])) call_user_func(static::$listenerStub[$event], $model);
         });
-        $dispatcher->shouldReceive('fire')->andReturnUsing(function($event, $model)
+        $dispatcher->shouldReceive('dispatch')->andReturnUsing(function($event, $model)
         {
             if (isset(static::$listenerStub[$event])) call_user_func(static::$listenerStub[$event], $model);
         });
@@ -278,7 +277,7 @@ class OBOne extends Model {
             }
             elseif (isset(static::$listenerStub[$event])) call_user_func(static::$listenerStub[$event], $model);
         });
-        $dispatcher->shouldReceive('fire')->andReturnUsing(function($event, $model)
+        $dispatcher->shouldReceive('dispatch')->andReturnUsing(function($event, $model)
         {
             if (isset(static::$listenerStub[$event]) and strpos(static::$listenerStub[$event], '@') !== false)
             {

--- a/tests/functional/QueryScopesTest.php
+++ b/tests/functional/QueryScopesTest.php
@@ -19,6 +19,11 @@ class Misfit extends Model {
     {
         return $query->where('alias', 'edison');
     }
+
+    public function scopeWhereName($query, $name)
+    {
+        return $query->where('name', $name);
+    }
 }
 
 class QueryScopesTest extends TestCase {
@@ -58,6 +63,9 @@ class QueryScopesTest extends TestCase {
         $this->assertEquals($this->t->toArray(), $t->toArray());
 
         $e = Misfit::stupidDickhead()->first();
+        $this->assertEquals($this->e->toArray(), $e->toArray());
+
+        $e = Misfit::whereName('Thomas Edison')->stupidDickhead()->first();
         $this->assertEquals($this->e->toArray(), $e->toArray());
     }
 }

--- a/tests/functional/QueryingRelationsTest.php
+++ b/tests/functional/QueryingRelationsTest.php
@@ -618,8 +618,7 @@ class QueryingRelationsTest extends TestCase {
         ]);
 
         $format = $user->getDateFormat();
-
-        $houwe = User::first();
+        $houwe = User::find($user->id);
         $colleague = $houwe->colleagues()->first();
 
         $this->assertEquals($yesterday->format($format), $houwe->dob);

--- a/tests/functional/SimpleCRUDTest.php
+++ b/tests/functional/SimpleCRUDTest.php
@@ -233,7 +233,7 @@ class SimpleCRUDTest extends TestCase {
             $this->assertArrayHasKey('id', $values);
             $this->assertGreaterThanOrEqual(0, $values['id']);
             unset($values['id']);
-            $this->assertEquals($batch[$key], $values);
+            $this->assertContains($values, $batch);
         }
     }
 

--- a/tests/functional/WheresTheTest.php
+++ b/tests/functional/WheresTheTest.php
@@ -297,4 +297,10 @@ class WheresTheTest extends TestCase {
         $this->assertEquals($this->cd->toArray(), $users[0]->toArray());
         $this->assertEquals($this->ef->toArray(), $users[1]->toArray());
     }
+
+    public function testWhereRaw()
+    {
+        $ab = User::whereRaw('name = ?', [$this->ab->name]);
+        $this->assertEquals($this->ab->toArray(), $ab->toArray());
+    }
 }

--- a/tests/functional/WheresTheTest.php
+++ b/tests/functional/WheresTheTest.php
@@ -300,7 +300,7 @@ class WheresTheTest extends TestCase {
 
     public function testWhereRaw()
     {
-        $ab = User::whereRaw('name = ?', [$this->ab->name]);
-        $this->assertEquals($this->ab->toArray(), $ab->toArray());
+        $ab = User::whereRaw('individual.name = {name}', ['name' => $this->ab->name])->get();
+        $this->assertEquals($this->ab->toArray(), $ab[0]->toArray());
     }
 }


### PR DESCRIPTION
When combining whereRaw with a global scope such as softdeletes we would get problems with addBindings and columnCountForWhereClause that weren't expecting a raw query.