### PR TITLE
V1.8

### DIFF
--- a/src/ConnectionAdapter.php
+++ b/src/ConnectionAdapter.php
@@ -4,6 +4,7 @@ namespace Vinelab\NeoEloquent;
 
 use Closure;
 use Exception;
+use Throwable;
 use Vinelab\NeoEloquent\Exceptions\QueryException;
 use Vinelab\NeoEloquent\ConnectionInterface;
 
@@ -108,7 +109,7 @@ class ConnectionAdapter extends BaseConnection implements ConnectionInterface
 	 * @param  array   $bindings
 	 * @return mixed
 	 */
-	public function selectOne($query, $bindings = array())
+	public function selectOne($query, $bindings = array(), $useReadPdo = true)
 	{
         return $this->neoeloquent->selectOne($query, $bindings);
 	}
@@ -258,7 +259,7 @@ class ConnectionAdapter extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return void
 	 */
-	public function rollBack()
+	public function rollBack($toLevel = null)
 	{
 		$this->neoeloquent->rollBack();
 	}
@@ -336,7 +337,7 @@ class ConnectionAdapter extends BaseConnection implements ConnectionInterface
 	 * @param  \Illuminate\Database\QueryException
 	 * @return bool
 	 */
-	protected function causedByLostConnection(Exception $e)
+	protected function causedByLostConnection(Throwable $e)
 	{
         return $this->neoeloquent->causedByLostConnection(new QueryException($e));
 	}

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -2,7 +2,6 @@
 
 namespace Vinelab\NeoEloquent\Eloquent;
 
-use BadMethodCallException;
 use DateTime;
 use Exception;
 use ArrayAccess;

--- a/src/MigrationServiceProvider.php
+++ b/src/MigrationServiceProvider.php
@@ -181,7 +181,7 @@ class  MigrationServiceProvider extends ServiceProvider {
     protected function registerMigrateMakeCommand()
     {
         $this->app->singleton('migration.neoeloquent.creator', function($app) {
-            return new MigrationCreator($app['files']);
+            return new MigrationCreator($app['files'], $app->basePath('stubs'));
         });
 
         $this->app->singleton('command.neoeloquent.migrate.make', function($app) {


### PR DESCRIPTION
Runs queries (unsuccessfully though) using driver, getting the following warnings/errors:

```
PHP Deprecated:  Return type of Laudis\Neo4j\Types\AbstractCypherObject::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/laudis/neo4j-php-client/src/Types/AbstractCypherObject.php on line 45
PHP Deprecated:  Return type of Laudis\Neo4j\Types\AbstractCypherObject::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/laudis/neo4j-php-client/src/Types/AbstractCypherObject.php on line 71
PHP Deprecated:  Return type of Laudis\Neo4j\Enum\AccessMode::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/laudis/neo4j-php-client/src/Enum/AccessMode.php on line 36
PHP Deprecated:  Return type of Laudis\Neo4j\Enum\QueryTypeEnum::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/laudis/neo4j-php-client/src/Enum/QueryTypeEnum.php on line 65
PHP Error:  Call to undefined method Laudis\Neo4j\Databags\SummarizedResult::getResult() in /home/sail/Developer/Code/NeoEloquent/NeoEloquent/src/Connection.php on line 635
```