### PR TITLE
Added support for selecting the database

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -451,6 +451,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the database name.
+     *
+     * @return null|string
+     */
+    public function getDatabase(array $config)
+    {
+        return Arr::get($config, 'database', null);
+    }
+
+    /**
      * Get the connection username.
      *
      * @return int|string
@@ -1208,6 +1218,11 @@ class Connection implements ConnectionInterface
         $port = $this->getPort($config);
         if ($port) {
             $uri .= ':' . $port;
+        }
+
+        $database = $this->getDatabase($config);
+        if ($database) {
+            $uri .= '?database='.urlencode($database);
         }
 
         return $uri;


### PR DESCRIPTION
Seems like there is no way of selecting the neo4j database despite the underlying connection driver supporting it.

This small changes will make it possible to specify a database other from the default `neo4j`.

Also I noticed that there is a possibly unused `protected $database` property that maybe served similar purpose. Could that be removed as well?