### PR TITLE
Fixed missing use declaration

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -28,6 +28,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 


### PR DESCRIPTION
When trying to fill a not fillable attribute, I received a class Vinelab\NeoEloquent\Eloquent\MassAssignmentException does not exist error.

I believe this is due to a missing use statement.