### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.floo              export-ignore
+/.flooignore        export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/phpunit.xml        export-ignore
+/Examples           export-ignore
+/tests              export-ignore
+/docker-compose.yml export-ignore
+/Dockerfile         export-ignore
+/.editorconfig      export-ignore
+/README.md          export-ignore


### PR DESCRIPTION
Avoids downloading extra files into the `vendor` folder by the composer.