### PR TITLE
Fixed invalid match when trying to attach to a node whose id is 0

### DIFF
--- a/src/Query/Grammars/CypherGrammar.php
+++ b/src/Query/Grammars/CypherGrammar.php
@@ -871,8 +871,9 @@ class CypherGrammar extends Grammar
             $endKey = $attributes['end']['id']['key'];
             $endNode = 'rel_'.$this->modelAsNode($attributes['label']);
             $endLabel = $this->prepareLabels($attributes['end']['label']);
+            $endId = null;
 
-            if ($attributes['end']['id']['value']) {
+            if ($attributes['end']['id']['value'] || $attributes['end']['id']['value'] === 0) {
                 if ($endKey === 'id') {
                     // when it's 'id' it has to be numeric
                     $endKey = 'id('.$endNode.')';
@@ -883,7 +884,7 @@ class CypherGrammar extends Grammar
                 }
             }
 
-            $endCondition = (!empty($endId)) ? $endKey.'='.$endId : '';
+            $endCondition = (!is_null($endId)) ? $endKey.'='.$endId : '';
 
             $query .= ", ($endNode$endLabel)";
         }

--- a/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
+++ b/tests/Vinelab/NeoEloquent/Query/GrammarTest.php
@@ -131,4 +131,40 @@ class GrammarTest extends TestCase
         $this->assertEquals('idcola', $this->grammar->getIdReplacement('id'));
         $this->assertEquals('iddd', $this->grammar->getIdReplacement('id(dd)'));
     }
+    
+    public function testCompileMatchRelationship()
+    {
+        $builder = M::mock('Vinelab\NeoEloquent\Query\Builder');
+        $attributes = [
+            'label' => 'WROTE',
+            'start' => [
+                'id' => ['key' => 'id', 'value' => 12],
+                'label' => ['Author'],
+            ],
+            'end' => [
+                'id' => ['key' => 'id', 'value' => 11],
+                'label' => ['Book'],
+            ],
+        ];
+        
+        $this->assertEquals('MATCH (author:`Author`), (rel_wrote:`Book`) WHERE id(author)=12 AND id(rel_wrote)=11', $this->grammar->compileMatchRelationship($builder, $attributes));
+    }
+
+    public function testCompileMatchRelationshipWithZeroEndId()
+    {
+        $builder = M::mock('Vinelab\NeoEloquent\Query\Builder');
+        $attributes = [
+            'label' => 'WROTE',
+            'start' => [
+                'id' => ['key' => 'id', 'value' => 12],
+                'label' => ['Author'],
+            ],
+            'end' => [
+                'id' => ['key' => 'id', 'value' => 0],
+                'label' => ['Book'],
+            ],
+        ];
+        
+        $this->assertEquals('MATCH (author:`Author`), (rel_wrote:`Book`) WHERE id(author)=12 AND id(rel_wrote)=0', $this->grammar->compileMatchRelationship($builder, $attributes));
+    }
 }


### PR DESCRIPTION
When trying to attach a node where the id is `0` the generated CypherQuery was missing the end node from the MATCH part.

This bug come out when neo started to reuse ids of deleted nodes: because the first id is 0, when this happened instead of connecting to the new node, a ton of edges were created between nodes with the same label.

This patch checks if the end node has an id, and won't ignore it from the query even if the value is the numeric `0`.

For missing values (`false`, `null`, `unset`) the behavior was not changed.

I have also added a unit test to visualize the problem.
