### PR TITLE
PHP8.2 & Laravel 10 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^8.2",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
-        "illuminate/collections": "^10.0",
         "illuminate/database": "^10.0",
         "illuminate/events": "^10.0",
         "illuminate/support": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8",
+        "php": "^8.2",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/database": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
         "illuminate/database": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -20,22 +20,22 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "illuminate/container": "^8.0",
-        "illuminate/contracts": "^8.0",
-        "illuminate/database": "^8.0",
-        "illuminate/events": "^8.0",
-        "illuminate/support": "^8.0",
-        "illuminate/pagination": "^8.0",
+        "php": "^8.2",
+        "illuminate/container": "^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/database": "^10.0",
+        "illuminate/events": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/pagination": "^10.0",
         "nesbot/carbon": "^2.0",
-        "laudis/neo4j-php-client": "^2.3.3"
+        "laudis/neo4j-php-client": "^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "~1.3.0",
-        "phpunit/phpunit": "^9.0",
+        "mockery/mockery": "~1.6.0",
+        "phpunit/phpunit": "^10.0",
         "symfony/var-dumper": "*",
-        "fzaninotto/faker": "~1.4",
-        "composer/composer": "^2.1"
+        "fakerphp/faker": "^1.9.1",
+        "composer/composer": "^2.6"
     },
     "autoload": {
         "psr-4": {
@@ -53,6 +53,11 @@
             "providers": [
                 "Vinelab\\NeoEloquent\\NeoEloquentServiceProvider"
             ]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "illuminate/events": "^10.0",
         "illuminate/support": "^10.0",
         "illuminate/pagination": "^10.0",
+        "illuminate/console": "^10.0",
         "nesbot/carbon": "^2.0",
         "laudis/neo4j-php-client": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^8.2",
         "illuminate/container": "^10.0",
         "illuminate/contracts": "^10.0",
+        "illuminate/collections": "^10.0",
         "illuminate/database": "^10.0",
         "illuminate/events": "^10.0",
         "illuminate/support": "^10.0",

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1071,7 +1071,7 @@ class Connection implements ConnectionInterface
     /**
      * Reconnect to the database if a PDO connection is missing.
      */
-    protected function reconnectIfMissingConnection()
+    public function reconnectIfMissingConnection()
     {
         if (is_null($this->getClient())) {
             $this->reconnect();

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -926,11 +926,9 @@ class Connection implements ConnectionInterface
 
         return $query->from($label);
     }
-
+    
     /**
      * Get a new query builder instance.
-     *
-     * @return \Illuminate\Database\Query\Builder
      */
     public function query()
     {

--- a/src/ConnectionAdapter.php
+++ b/src/ConnectionAdapter.php
@@ -369,7 +369,7 @@ class ConnectionAdapter extends BaseConnection implements ConnectionInterface
 	 *
 	 * @return void
 	 */
-	protected function reconnectIfMissingConnection()
+    public function reconnectIfMissingConnection()
 	{
 		$this->neoeloquent->reconnectIfMissingConnection();
 	}

--- a/src/ConnectionAdapter.php
+++ b/src/ConnectionAdapter.php
@@ -3,11 +3,9 @@
 namespace Vinelab\NeoEloquent;
 
 use Closure;
-use Exception;
+use Illuminate\Support\Facades\App;
 use Throwable;
 use Vinelab\NeoEloquent\Exceptions\QueryException;
-use Vinelab\NeoEloquent\ConnectionInterface;
-
 use Illuminate\Contracts\Events\Dispatcher as IlluminateDispatcher;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
@@ -535,15 +533,14 @@ class ConnectionAdapter extends BaseConnection implements ConnectionInterface
 		return $this->neoeloquent->getEventDispatcher();
 	}
 
-	/**
-	 * Set the event dispatcher instance on the connection.
-	 *
-	 * @param  \Illuminate\Contracts\Events\Dispatcher
-	 * @return void
-	 */
-	public function setEventDispatcher(IlluminateDispatcher $events)
+    /**
+     * @param  IlluminateDispatcher  $events
+     *
+     * @return void
+     */
+    public function setEventDispatcher(IlluminateDispatcher $events)
 	{
-		$this->neoeloquent->setEventDispatcher(\App::make(Dispatcher::class));
+		$this->neoeloquent->setEventDispatcher(App::make(Dispatcher::class));
 	}
 
 	/**

--- a/src/Console/Migrations/MigrateCommand.php
+++ b/src/Console/Migrations/MigrateCommand.php
@@ -20,61 +20,39 @@ class MigrateCommand extends BaseCommand
      */
     protected $description = 'Run the database migrations';
 
-    /**
-     * The migrator instance.
-     *
-     * @var \Vinelab\NeoEloquent\Migrations\Migrator
-     */
-    protected $migrator;
-
-    /**
-     * The path to the packages directory (vendor).
-     */
-    protected $packagePath;
-
-    /**
-     * @param \Vinelab\NeoEloquent\Migrations\Migrator $migrator
-     * @param string                                   $packagePath
-     */
-    public function __construct(Migrator $migrator, $packagePath)
+    public function __construct(protected Migrator $migrator, protected string $packagePath)
     {
         parent::__construct();
-
-        $this->migrator = $migrator;
-        $this->packagePath = $packagePath;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function fire()
+    public function handle()
     {
-        if (!$this->confirmToProceed()) {
+        if(!$this->confirmToProceed()) {
             return;
         }
 
         // The pretend option can be used for "simulating" the migration and grabbing
         // the SQL queries that would fire if the migration were to be run against
         // a database for real, which is helpful for double checking migrations.
-        $pretend = $this->input->getOption('pretend');
+        $pretend = $this->input->getOption(name: 'pretend');
 
         $path = $this->getMigrationPath();
 
-        $this->migrator->setConnection($this->input->getOption('database'));
-        $this->migrator->run($path, ['pretend' => $pretend]);
+        $this->migrator->setConnection(name: $this->input->getOption(name: 'database'));
+        $this->migrator->run(paths: $path, options: ['pretend' => $pretend]);
 
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
         // any instances of the OutputInterface contract passed into the class.
-        foreach ($this->migrator->getNotes() as $note) {
-            $this->output->writeln($note);
+        foreach($this->migrator->getNotes() as $note) {
+            $this->output->writeln(messages: $note);
         }
 
         // Finally, if the "seed" option has been given, we will re-run the database
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.
-        if ($this->input->getOption('seed')) {
-            $this->call('db:seed', ['--force' => true]);
+        if($this->input->getOption(name: 'seed')) {
+            $this->call(command: 'db:seed', arguments: ['--force' => true]);
         }
     }
 
@@ -83,20 +61,20 @@ class MigrateCommand extends BaseCommand
      */
     protected function getOptions()
     {
-        return array(
-            array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+        return [
+            ['bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null],
 
-            array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-            array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-            array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null],
 
-            array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
+            ['package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null],
 
-            array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 
-            array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
-        );
+            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+        ];
     }
 }

--- a/src/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Console/Migrations/MigrateMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Vinelab\NeoEloquent\Console\Migrations;
 
+use Exception;
 use Illuminate\Support\Composer;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -19,105 +20,72 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected $description = 'Create a new migration file';
 
-    /**
-     * @var \Vinelab\NeoEloquent\Migrations\MigrationCreator
-     */
-    protected $creator;
-
-    /**
-     * The path to the packages directory (vendor).
-     *
-     * @var string
-     */
-    protected $packagePath;
-
-    /**
-     * @var \Illuminate\Foundation\Composer
-     */
-    protected $composer;
-
-    /**
-     * @param \Vinelab\NeoEloquent\Migrations\MigrationCreator $creator
-     * @param string                                           $packagePath
-     */
-    public function __construct(MigrationCreator $creator, Composer $composer, $packagePath)
+    public function __construct(protected MigrationCreator $creator, protected Composer $composer, protected string $packagePath)
     {
         parent::__construct();
 
-        $this->creator = $creator;
-        $this->packagePath = $packagePath;
-        $this->composer = $composer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function fire()
+    public function handle(): void
     {
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this label needs
         // to be freshly created so we can create the appropriate migrations.
-        $name = $this->input->getArgument('name');
+        $name = $this->input->getArgument(name: 'name');
 
-        $label = $this->input->getOption('label');
+        $label = $this->input->getOption(name: 'label');
 
-        $modify = $this->input->getOption('create');
+        $modify = $this->input->getOption(name: 'create');
 
-        if (!$label && is_string($modify)) {
+        if(!$label && \is_string(value: $modify)) {
             $label = $modify;
         }
 
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $label);
+        $this->writeMigration(name: $name, label: $label);
 
         $this->composer->dumpAutoloads();
     }
 
     /**
-     * Write the migration file to disk.
-     *
-     * @param string $name
-     * @param string $label
-     * @param bool   $create
-     *
-     * @return string
+     * @throws Exception
      */
-    protected function writeMigration($name, $label)
+    protected function writeMigration(string $name, string $label = null): void
     {
         $path = $this->getMigrationPath();
 
-        $file = pathinfo($this->creator->create($name, $path, $label), PATHINFO_FILENAME);
+        $file = pathinfo(path: $this->creator->create(name: $name, path: $path, table: $label), flags: PATHINFO_FILENAME);
 
-        $this->line("<info>Created Migration:</info> $file");
+        $this->line(string: "<info>Created Migration:</info> $file");
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
-        return array(
-            array('name', InputArgument::REQUIRED, 'The name of the migration'),
-        );
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the migration'],
+        ];
     }
 
     /**
      * {@inheritDoc}
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
-        return array(
-            array('bench', null, InputOption::VALUE_OPTIONAL, 'The workbench the migration belongs to.', null),
+        return [
+            ['bench', null, InputOption::VALUE_OPTIONAL, 'The workbench the migration belongs to.', null],
 
-            array('create', null, InputOption::VALUE_OPTIONAL, 'The label schema to be created.'),
+            ['create', null, InputOption::VALUE_OPTIONAL, 'The label schema to be created.'],
 
-            array('package', null, InputOption::VALUE_OPTIONAL, 'The package the migration belongs to.', null),
+            ['package', null, InputOption::VALUE_OPTIONAL, 'The package the migration belongs to.', null],
 
-            array('path', null, InputOption::VALUE_OPTIONAL, 'Where to store the migration.', null),
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Where to store the migration.', null],
 
-            array('label', null, InputOption::VALUE_OPTIONAL, 'The label to migrate.'),
-        );
+            ['label', null, InputOption::VALUE_OPTIONAL, 'The label to migrate.'],
+        ];
     }
 }

--- a/src/Eloquent/Edges/Delegate.php
+++ b/src/Eloquent/Edges/Delegate.php
@@ -256,7 +256,7 @@ abstract class Delegate
             unset($properties['id']);
         }
 
-        return new Node($id, new CypherList([$label]), new CypherMap($properties));
+        return new Node($id, new CypherList([$label]), new CypherMap($properties), null);
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -792,7 +792,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @override
      * Get a new query builder instance for the connection.
      *
-     * @return Vinelab\NeoEloquent\Query\Builder
+     * @return QueryBuilder
      */
     protected function newBaseQueryBuilder()
     {

--- a/src/MigrationServiceProvider.php
+++ b/src/MigrationServiceProvider.php
@@ -13,24 +13,16 @@ use Vinelab\NeoEloquent\Migrations\DatabaseMigrationRepository;
 use Vinelab\NeoEloquent\Console\Migrations\MigrateRefreshCommand;
 use Vinelab\NeoEloquent\Console\Migrations\MigrateRollbackCommand;
 
-class  MigrationServiceProvider extends ServiceProvider {
-
-    /**
-     * {@inheritDoc}
-     */
+class  MigrationServiceProvider extends ServiceProvider
+{
     protected $defer = true;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function boot()
-    {
-    }
+    public function boot() {}
 
     /**
      * {@inheritDoc}
      */
-    public function register()
+    public function register(): void
     {
         $this->registerRepository();
 
@@ -45,66 +37,67 @@ class  MigrationServiceProvider extends ServiceProvider {
     /**
      * Register the migration repository service.
      *
-     * @return void
      */
-    protected function registerRepository()
+    protected function registerRepository(): void
     {
-        $this->app->singleton('neoeloquent.migration.repository', function($app)
-        {
-            $model = new MigrationModel;
+        $this->app->singleton(
+            abstract: 'neoeloquent.migration.repository',
+            concrete: function($app) {
+                $model = new MigrationModel();
 
-            $label = $app['config']['database.migrations_node'];
+                $label = $app['config']['database.migrations_node'];
 
-            if (isset($label)) {
-                $model->setLabel($label);
-            }
+                if(isset($label)) {
+                    $model->setLabel(label: $label);
+                }
 
-            return new DatabaseMigrationRepository(
-                $app['db'],
-                $app['db']->connection('neo4j')->getSchemaBuilder(),
-                $model
-            );
-        });
+                return new DatabaseMigrationRepository(
+                    resolver: $app['db'],
+                    schema  : $app['db']->connection('neo4j')->getSchemaBuilder(),
+                    model   : $model,
+                );
+            },
+        );
     }
 
     /**
      * Register the migrator service.
      *
-     * @return void
      */
-    protected function registerMigrator()
+    protected function registerMigrator(): void
     {
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('neoeloquent.migrator', function($app) {
-            $repository = $app['neoeloquent.migration.repository'];
+        $this->app->singleton(
+            abstract: 'neoeloquent.migrator',
+            concrete: function($app) {
+                $repository = $app['neoeloquent.migration.repository'];
 
-            return new Migrator($repository, $app['db'], $app['files']);
-        });
+                return new Migrator(repository: $repository, resolver: $app['db'], files: $app['files']);
+            },
+        );
     }
 
 
     /**
      * Register all of the migration commands.
      *
-     * @return void
      */
-    protected function registerCommands()
+    protected function registerCommands(): void
     {
-        $commands = array(
+        $commands = [
             'Migrate',
             'MigrateRollback',
             'MigrateReset',
             'MigrateRefresh',
-            'MigrateMake'
-        );
+            'MigrateMake',
+        ];
 
         // We'll simply spin through the list of commands that are migration related
         // and register each one of them with an application container. They will
         // be resolved in the Artisan start file and registered on the console.
-        foreach ($commands as $command)
-        {
+        foreach($commands as $command) {
             $this->{'register'.$command.'Command'}();
         }
 
@@ -116,94 +109,104 @@ class  MigrationServiceProvider extends ServiceProvider {
             'command.neoeloquent.migrate.make',
             'command.neoeloquent.migrate.rollback',
             'command.neoeloquent.migrate.reset',
-            'command.neoeloquent.migrate.refresh'
+            'command.neoeloquent.migrate.refresh',
         );
     }
 
     /**
      * Register the "migrate" migration command.
      *
-     * @return void
      */
-    protected function registerMigrateCommand()
+    protected function registerMigrateCommand(): void
     {
-        $this->app->singleton('command.neoeloquent.migrate', function($app) {
-            $packagePath = $app['path.base'].'/vendor';
+        $this->app->singleton(
+            abstract: 'command.neoeloquent.migrate',
+            concrete: function($app) {
+                $packagePath = $app['path.base'].'/vendor';
 
-            return new MigrateCommand($app['neoeloquent.migrator'], $packagePath);
-        });
+                return new MigrateCommand(migrator: $app['neoeloquent.migrator'], packagePath: $packagePath);
+            },
+        );
     }
 
     /**
      * Register the "rollback" migration command.
      *
-     * @return void
      */
-    protected function registerMigrateRollbackCommand()
+    protected function registerMigrateRollbackCommand(): void
     {
-        $this->app->singleton('command.neoeloquent.migrate.rollback', function($app)
-        {
-            return new MigrateRollbackCommand($app['neoeloquent.migrator']);
-        });
+        $this->app->singleton(
+            abstract: 'command.neoeloquent.migrate.rollback',
+            concrete: function($app) {
+                return new MigrateRollbackCommand(migrator: $app['neoeloquent.migrator']);
+            },
+        );
     }
 
     /**
      * Register the "reset" migration command.
      *
-     * @return void
      */
-    protected function registerMigrateResetCommand()
+    protected function registerMigrateResetCommand(): void
     {
-        $this->app->singleton('command.neoeloquent.migrate.reset', function($app)
-        {
-            return new MigrateResetCommand($app['neoeloquent.migrator']);
-        });
+        $this->app->singleton(
+            abstract: 'command.neoeloquent.migrate.reset',
+            concrete: function($app) {
+                return new MigrateResetCommand(migrator: $app['neoeloquent.migrator']);
+            },
+        );
     }
 
     /**
      * Register the "refresh" migration command.
      *
-     * @return void
      */
-    protected function registerMigrateRefreshCommand()
+    protected function registerMigrateRefreshCommand(): void
     {
-        $this->app->singleton('command.neoeloquent.migrate.refresh', function($app)
-        {
-            return new MigrateRefreshCommand();
-        });
+        $this->app->singleton(
+            abstract: 'command.neoeloquent.migrate.refresh',
+            concrete: function($app) {
+                return new MigrateRefreshCommand();
+            },
+        );
     }
 
     /**
      * Register the "install" migration command.
      *
-     * @return void
      */
-    protected function registerMigrateMakeCommand()
+    protected function registerMigrateMakeCommand(): void
     {
-        $this->app->singleton('migration.neoeloquent.creator', function($app) {
-            return new MigrationCreator($app['files'], $app->basePath('stubs'));
-        });
+        $this->app->singleton(
+            abstract: 'migration.neoeloquent.creator',
+            concrete: function($app) {
+                return new MigrationCreator(files: $app['files'], customStubPath: $app->basePath('stubs'));
+            },
+        );
 
-        $this->app->singleton('command.neoeloquent.migrate.make', function($app) {
-            // Once we have the migration creator registered, we will create the command
-            // and inject the creator. The creator is responsible for the actual file
-            // creation of the migrations, and may be extended by these developers.
-            $creator = $app['migration.neoeloquent.creator'];
+        $this->app->singleton(
+            abstract: 'command.neoeloquent.migrate.make',
+            concrete: function($app) {
+                // Once we have the migration creator registered, we will create the command
+                // and inject the creator. The creator is responsible for the actual file
+                // creation of the migrations, and may be extended by these developers.
+                $creator = $app['migration.neoeloquent.creator'];
 
-            $packagePath = $app['path.base'].'/vendor';
+                $packagePath = $app['path.base'].'/vendor';
 
-            $composer = $app->make('Illuminate\Support\Composer');
+                $composer = $app->make('Illuminate\Support\Composer');
 
-            return new MigrateMakeCommand($creator, $composer, $packagePath);
-        });
+                return new MigrateMakeCommand(creator: $creator, composer: $composer, packagePath: $packagePath);
+            },
+        );
     }
 
     /**
      * {@inheritDoc}
      */
-    public function provides()
+    public function provides(): array
     {
-        return array(
+        return [
             'neoeloquent.migrator',
             'neoeloquent.migration.repository',
             'command.neoeloquent.migrate',
@@ -212,7 +215,7 @@ class  MigrationServiceProvider extends ServiceProvider {
             'command.neoeloquent.migrate.refresh',
             'migration.neoeloquent.creator',
             'command.neoeloquent.migrate.make',
-        );
+        ];
     }
 
 }

--- a/src/Migrations/DatabaseMigrationRepository.php
+++ b/src/Migrations/DatabaseMigrationRepository.php
@@ -47,7 +47,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function getRan()
     {
-        return $this->model->all()->lists('migration');
+        return $this->model->all()->pluck('migration')->toArray();
     }
 
     /**

--- a/src/Migrations/DatabaseMigrationRepository.php
+++ b/src/Migrations/DatabaseMigrationRepository.php
@@ -64,6 +64,21 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Get the list of the migrations by batch number.
+     *
+     * @param  int  $batch
+     * @return array
+     */
+    public function getMigrationsByBatch($batch)
+    {
+        return $this->label()
+                    ->where('batch', $batch)
+                    ->orderBy('migration', 'desc')
+                    ->get()
+                    ->all();
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getLast()

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -2,11 +2,12 @@
 
 namespace Vinelab\NeoEloquent\Migrations;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Migrations\MigrationCreator as IlluminateMigrationCreator;
+use Illuminate\Support\Str;
 
 class MigrationCreator extends IlluminateMigrationCreator
 {
-
     /**
      * @param  string       $stub
      * @param  null|string  $table
@@ -15,6 +16,8 @@ class MigrationCreator extends IlluminateMigrationCreator
      */
     protected function populateStub($stub, $table)
     {
+        $stub = str_replace('{{class}}', Str::studly($table), $stub);
+
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
@@ -29,9 +32,57 @@ class MigrationCreator extends IlluminateMigrationCreator
     }
 
     /**
-     * {@inheritDoc}
+     * @throws FileNotFoundException
      */
-    public function getStubPath()
+    protected function getStub($table, $create)
+    {
+        $customPath = $this->customStubPath;
+        if ($table === null) {
+            $stub = $this->files->exists(path: "$customPath/blank.stub")
+                ? $customPath
+                : $this->stubPath().'/blank.stub';
+        } elseif ($create) {
+            $stub = $this->files->exists(path: "$customPath/create.stub")
+                ? $customPath
+                : $this->stubPath().'/create.stub';
+        } else {
+            $stub = $this->files->exists(path: "$customPath/update.stub")
+                ? $customPath
+                : $this->stubPath().'/update.stub';
+        }
+
+        return $this->files->get($stub);
+    }
+
+    public function create($name, $path, $table = null, $create = false)
+    {
+        $this->ensureMigrationDoesntAlreadyExist($name, $path);
+
+        // First we will get the stub file for the migration, which serves as a type
+        // of template for the migration. Once we have those we will populate the
+        // various place-holders, save the file, and run the post create event.
+        $stub = $this->getStub($table, $create);
+
+        $path = $this->getPath($name, $path);
+
+        $this->files->ensureDirectoryExists(\dirname($path));
+
+        $this->files->put(
+            $path, $this->populateStub($stub, $table ?? $name)
+        );
+
+        // Next, we will fire any hooks that are supposed to fire after a migration is
+        // created. Once that is done we'll be ready to return the full path to the
+        // migration file so it can be used however it's needed by the developer.
+        $this->firePostCreateHooks($table, $path);
+
+        return $path;
+    }
+
+    /**
+     * @return string
+     */
+    public function stubPath()
     {
         return __DIR__.'/stubs';
     }

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -8,8 +8,8 @@ class MigrationCreator extends IlluminateMigrationCreator
 {
 
     /**
-     * @param string $stub
-     * @param string $table
+     * @param  string       $stub
+     * @param  null|string  $table
      *
      * @return string
      */

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -6,11 +6,10 @@ use Illuminate\Database\Migrations\MigrationCreator as IlluminateMigrationCreato
 
 class MigrationCreator extends IlluminateMigrationCreator
 {
+
     /**
-     * Populate the place-holders in the migration stub.
-     *
      * @param string $stub
-     * @param string $label
+     * @param string $table
      *
      * @return string
      */
@@ -19,9 +18,9 @@ class MigrationCreator extends IlluminateMigrationCreator
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
-        if (! is_null($table)) {
+        if ($table !== null) {
             $stub = str_replace(
-                ['DummyTable', '{{ table }}', '{{table}}'],
+                ['{{ table }}', '{{table}}'],
                 $table, $stub
             );
         }

--- a/src/Migrations/MigrationCreator.php
+++ b/src/Migrations/MigrationCreator.php
@@ -9,21 +9,21 @@ class MigrationCreator extends IlluminateMigrationCreator
     /**
      * Populate the place-holders in the migration stub.
      *
-     * @param string $name
      * @param string $stub
      * @param string $label
      *
      * @return string
      */
-    protected function populateStub($name, $stub, $label)
+    protected function populateStub($stub, $table)
     {
-        $stub = str_replace('{{class}}', studly_case($name), $stub);
-
-        // Here we will replace the label place-holders with the label specified by
-        // the developer, which is useful for quickly creating a labels creation
+        // Here we will replace the table place-holders with the table specified by
+        // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
-        if (!is_null($label)) {
-            $stub = str_replace('{{label}}', $label, $stub);
+        if (! is_null($table)) {
+            $stub = str_replace(
+                ['DummyTable', '{{ table }}', '{{table}}'],
+                $table, $stub
+            );
         }
 
         return $stub;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -9,10 +9,8 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Types\CypherList;
-use Laudis\Neo4j\Types\CypherMap;
 use Laudis\Neo4j\Types\Node;
 use Vinelab\NeoEloquent\ConnectionInterface;
-use GraphAware\Common\Result\AbstractRecordCursor as Result;
 use Vinelab\NeoEloquent\Eloquent\Collection;
 use Vinelab\NeoEloquent\Query\Grammars\Grammar;
 
@@ -218,8 +216,6 @@ class Builder
 
     /**
      * Create a new query builder instance.
-     *
-     * @param Vinelab\NeoEloquent\Connection $connection
      */
     public function __construct(ConnectionInterface $connection, Grammar $grammar)
     {
@@ -1725,13 +1721,7 @@ class Builder
 
         $cypher = $this->grammar->compileDelete($this);
 
-        $result = $this->connection->delete($cypher, $this->getBindings());
-
-        if ($result instanceof Result) {
-            $result = true;
-        }
-
-        return $result;
+        return $this->connection->delete($cypher, $this->getBindings());
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -7,7 +7,9 @@ use DateTime;
 use Carbon\Carbon;
 use BadMethodCallException;
 use InvalidArgumentException;
+use Laudis\Neo4j\Databags\SummarizedResult;
 use Laudis\Neo4j\Types\CypherList;
+use Laudis\Neo4j\Types\CypherMap;
 use Laudis\Neo4j\Types\Node;
 use Vinelab\NeoEloquent\ConnectionInterface;
 use GraphAware\Common\Result\AbstractRecordCursor as Result;
@@ -453,7 +455,7 @@ class Builder
         }
 
         if (func_num_args() == 2) {
-            list($value, $operator) = array($operator, '=');
+            [$value, $operator] = array($operator, '=');
         } elseif ($this->invalidOperatorAndValue($operator, $value)) {
             throw new \InvalidArgumentException('Value must be provided.');
         }
@@ -469,7 +471,7 @@ class Builder
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.
         if (!in_array(mb_strtolower($operator), $this->operators, true)) {
-            list($value, $operator) = array($operator, '=');
+            [$value, $operator] = array($operator, '=');
         }
 
         // If the value is a Closure, it means the developer is performing an entire
@@ -1456,8 +1458,11 @@ class Builder
 
         $this->aggregate = ['function' => 'count', 'columns' => $columns];
 
+        /**
+         *
+         * @var SummarizedResult $results
+         */
         $results = $this->get();
-
         $this->aggregate = null;
 
         $this->restoreFieldsForCount();
@@ -1466,7 +1471,7 @@ class Builder
             return count($results);
         }
 
-        return isset($results[0]) ? (int) array_change_key_case((array) $results[0])['aggregate'] : 0;
+        return isset($results[0]) ? (int) $results->get(0)->get('count(*)') : 0;
     }
 
     /**
@@ -2251,8 +2256,8 @@ class Builder
     public function aggregate($function, $columns = array('*'), $percentile = null)
     {
         $this->aggregate = array_merge([
-            'label' => $this->from,
-        ], compact('function', 'columns', 'percentile'));
+                                           'label' => $this->from,
+                                       ], compact('function', 'columns', 'percentile'));
 
         $previousColumns = $this->columns;
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1404,7 +1404,7 @@ class Builder
      *
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 


### PR DESCRIPTION
I have this draft PR to support php8^ & Laravel 10. https://github.com/Vinelab/NeoEloquent/pull/374
It's made from my personal fork, I invite anyone to collaborate: https://github.com/Tachii/NeoEloquent

To install and run it, add this to your composer.json:

### Add at the top of the composer.json
```
"repositories": [
  {
    "type": "vcs",
    "url": "https://github.com/Tachii/NeoEloquent"
  }
 ]
 ```
### Add this into require block
```
"require": {
  "vinelab/neoeloquent": "dev-php-8-laravel-10"
}
```

What was done:

1. Replaced faker library that doesn't support php8^
2. Updated needed dependencies to the same version as in Laravel 10
3. Changed some of the methods to match parent classes/interfaces
4. Added missing methods introduced in Laravel 10